### PR TITLE
chore: pin Python Docker tag to 3.14.3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -53,7 +53,6 @@
       "description": "Pin and constrain Python Docker image to <3.14.4",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["python"],
-      "matchVersion": "/^3\\.1[0-3]\\./",
       "pinDigests": false,
       "pinVersions": ["3.14.3"],
       "allowedVersions": "<3.14.4"

--- a/renovate.json
+++ b/renovate.json
@@ -50,11 +50,13 @@
   "postUpdateOptions": ["uvLockUpdate"],
   "packageRules": [
     {
-      "description": "Pin Python Docker image to 3.14.3",
+      "description": "Pin and constrain Python Docker image to <3.14.4",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["python"],
+      "matchVersion": "/^3\\.1[0-3]\\./",
       "pinDigests": false,
-      "pinVersions": ["3.14.3"]
+      "pinVersions": ["3.14.3"],
+      "allowedVersions": "<3.14.4"
     },
     {
       "description": "Disable Docker digest pinning",

--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,13 @@
   "postUpdateOptions": ["uvLockUpdate"],
   "packageRules": [
     {
+      "description": "Pin Python Docker image to 3.14.3",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["python"],
+      "pinDigests": false,
+      "pinVersions": ["3.14.3"]
+    },
+    {
       "description": "Disable Docker digest pinning",
       "matchDatasources": ["docker"],
       "pinDigests": false

--- a/renovate.json
+++ b/renovate.json
@@ -50,12 +50,11 @@
   "postUpdateOptions": ["uvLockUpdate"],
   "packageRules": [
     {
-      "description": "Pin and constrain Python Docker image to <3.14.4",
+      "description": "Pin and constrain Python Docker image to 3.14.3",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["python"],
       "pinDigests": false,
-      "pinVersions": ["3.14.3"],
-      "allowedVersions": "<3.14.4"
+      "allowedVersions": "3.14.3"
     },
     {
       "description": "Disable Docker digest pinning",


### PR DESCRIPTION
Pins the renovate python Docker tag to 3.14.3 and enforces <3.14.4 constraint.