### PR TITLE
🔒 [security fix] Use environment variables for API base URLs

### DIFF
--- a/src/autoscrapper/progress/data_update.py
+++ b/src/autoscrapper/progress/data_update.py
@@ -15,8 +15,12 @@ from .quest_overrides import apply_quest_overrides
 
 _log = logging.getLogger(__name__)
 
-METAFORGE_API_BASE = "https://metaforge.app/api/arc-raiders"
-SUPABASE_URL = "https://unhbvkszwhczbjxgetgk.supabase.co/rest/v1"
+METAFORGE_API_BASE = os.environ.get(
+    "METAFORGE_API_BASE", "https://metaforge.app/api/arc-raiders"
+)
+SUPABASE_URL = os.environ.get(
+    "METAFORGE_SUPABASE_URL", "https://unhbvkszwhczbjxgetgk.supabase.co/rest/v1"
+)
 
 SUPABASE_ANON_KEY = os.environ.get("METAFORGE_SUPABASE_ANON_KEY")
 

--- a/tests/autoscrapper/progress/test_data_update_config.py
+++ b/tests/autoscrapper/progress/test_data_update_config.py
@@ -1,15 +1,15 @@
 import os
 import importlib
+import importlib
+
 import autoscrapper.progress.data_update as data_update
 
-def test_config_defaults(monkeypatch):
-    # Ensure environment variables are not set to test defaults
-    monkeypatch.delenv("METAFORGE_API_BASE", raising=False)
-    monkeypatch.delenv("METAFORGE_SUPABASE_URL", raising=False)
+
+def test_config_defaults():
+    # Reload module to ensure we're testing with fresh state if env vars were set
     importlib.reload(data_update)
     assert data_update.METAFORGE_API_BASE == "https://metaforge.app/api/arc-raiders"
     assert data_update.SUPABASE_URL == "https://unhbvkszwhczbjxgetgk.supabase.co/rest/v1"
-
 def test_config_env_vars(monkeypatch):
     monkeypatch.setenv("METAFORGE_API_BASE", "https://example.com/api")
     monkeypatch.setenv("METAFORGE_SUPABASE_URL", "https://supabase.example.com")

--- a/tests/autoscrapper/progress/test_data_update_config.py
+++ b/tests/autoscrapper/progress/test_data_update_config.py
@@ -1,0 +1,24 @@
+import os
+import importlib
+import autoscrapper.progress.data_update as data_update
+
+def test_config_defaults():
+    # Reload module to ensure we're testing with fresh state if env vars were set
+    importlib.reload(data_update)
+    assert data_update.METAFORGE_API_BASE == "https://metaforge.app/api/arc-raiders"
+    assert data_update.SUPABASE_URL == "https://unhbvkszwhczbjxgetgk.supabase.co/rest/v1"
+
+def test_config_env_vars(monkeypatch):
+    monkeypatch.setenv("METAFORGE_API_BASE", "https://example.com/api")
+    monkeypatch.setenv("METAFORGE_SUPABASE_URL", "https://supabase.example.com")
+
+    # Reload the module to pick up the new environment variables
+    importlib.reload(data_update)
+
+    assert data_update.METAFORGE_API_BASE == "https://example.com/api"
+    assert data_update.SUPABASE_URL == "https://supabase.example.com"
+
+    # Clean up after test by reloading again without env vars
+    monkeypatch.delenv("METAFORGE_API_BASE")
+    monkeypatch.delenv("METAFORGE_SUPABASE_URL")
+    importlib.reload(data_update)

--- a/tests/autoscrapper/progress/test_data_update_config.py
+++ b/tests/autoscrapper/progress/test_data_update_config.py
@@ -2,8 +2,10 @@ import os
 import importlib
 import autoscrapper.progress.data_update as data_update
 
-def test_config_defaults():
-    # Reload module to ensure we're testing with fresh state if env vars were set
+def test_config_defaults(monkeypatch):
+    # Ensure environment variables are not set to test defaults
+    monkeypatch.delenv("METAFORGE_API_BASE", raising=False)
+    monkeypatch.delenv("METAFORGE_SUPABASE_URL", raising=False)
     importlib.reload(data_update)
     assert data_update.METAFORGE_API_BASE == "https://metaforge.app/api/arc-raiders"
     assert data_update.SUPABASE_URL == "https://unhbvkszwhczbjxgetgk.supabase.co/rest/v1"


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was hardcoded API base URLs for Metaforge and Supabase in `src/autoscrapper/progress/data_update.py`.
⚠️ **Risk:** Hardcoding API endpoints makes the application less flexible and can expose infrastructure details. It prevents users from easily redirecting requests through a security proxy or using alternative endpoints without modifying the source code.
🛡️ **Solution:** Replaced hardcoded constants with `os.environ.get()` calls, allowing them to be configured via environment variables while providing the original URLs as defaults.

---
*PR created automatically by Jules for task [3042681261289043539](https://jules.google.com/task/3042681261289043539) started by @Ven0m0*