### PR TITLE
🔒 Remove hardcoded Supabase Anon Key

### DIFF
--- a/src/autoscrapper/progress/data_update.py
+++ b/src/autoscrapper/progress/data_update.py
@@ -243,7 +243,7 @@ def update_data_snapshot(data_dir: Optional[Path] = None) -> dict:
     mapped_items = [
         _map_metaforge_item(item, crafting_map, recycle_map) for item in metaforge_items
     ]
-    mapped_quests = [_map_metaforge_quest(quest) for metaforge_quests]
+    mapped_quests = [_map_metaforge_quest(quest) for quest in metaforge_quests]
     mapped_quests = apply_quest_overrides(mapped_quests)
 
     (data_dir / "items.json").write_text(

--- a/src/autoscrapper/progress/data_update.py
+++ b/src/autoscrapper/progress/data_update.py
@@ -18,10 +18,7 @@ _log = logging.getLogger(__name__)
 METAFORGE_API_BASE = "https://metaforge.app/api/arc-raiders"
 SUPABASE_URL = "https://unhbvkszwhczbjxgetgk.supabase.co/rest/v1"
 
-SUPABASE_ANON_KEY = os.environ.get(
-    "METAFORGE_SUPABASE_ANON_KEY",
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InVuaGJ2a3N6d2hjemJqeGdldGdrIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDQ5NjgwMjUsImV4cCI6MjA2MDU0NDAyNX0.gckCmxnlpwwJOGmc5ebLYDnaWaxr5PW31eCrSPR5aRQ",
-)
+SUPABASE_ANON_KEY = os.environ.get("METAFORGE_SUPABASE_ANON_KEY")
 
 
 class DownloadError(RuntimeError):
@@ -98,6 +95,11 @@ def _fetch_all_quests() -> List[dict]:
 
 
 def _fetch_supabase_all(table: str) -> List[dict]:
+    if not SUPABASE_ANON_KEY:
+        raise DownloadError(
+            "METAFORGE_SUPABASE_ANON_KEY environment variable is not set"
+        )
+
     headers = {
         "apikey": SUPABASE_ANON_KEY,
         "Authorization": f"Bearer {SUPABASE_ANON_KEY}",

--- a/src/autoscrapper/progress/data_update.py
+++ b/src/autoscrapper/progress/data_update.py
@@ -18,9 +18,9 @@ _log = logging.getLogger(__name__)
 METAFORGE_API_BASE = "https://metaforge.app/api/arc-raiders"
 SUPABASE_URL = "https://unhbvkszwhczbjxgetgk.supabase.co/rest/v1"
 
+SUPABASE_ANON_KEY = os.environ.get("METAFORGE_SUPABASE_ANON_KEY")
 
-def _get_supabase_anon_key() -> Optional[str]:
-    return os.environ.get("METAFORGE_SUPABASE_ANON_KEY")
+
 class DownloadError(RuntimeError):
     pass
 
@@ -243,7 +243,7 @@ def update_data_snapshot(data_dir: Optional[Path] = None) -> dict:
     mapped_items = [
         _map_metaforge_item(item, crafting_map, recycle_map) for item in metaforge_items
     ]
-    mapped_quests = [_map_metaforge_quest(quest) for quest in metaforge_quests]
+    mapped_quests = [_map_metaforge_quest(quest) for metaforge_quests]
     mapped_quests = apply_quest_overrides(mapped_quests)
 
     (data_dir / "items.json").write_text(

--- a/src/autoscrapper/progress/data_update.py
+++ b/src/autoscrapper/progress/data_update.py
@@ -18,9 +18,9 @@ _log = logging.getLogger(__name__)
 METAFORGE_API_BASE = "https://metaforge.app/api/arc-raiders"
 SUPABASE_URL = "https://unhbvkszwhczbjxgetgk.supabase.co/rest/v1"
 
-SUPABASE_ANON_KEY = os.environ.get("METAFORGE_SUPABASE_ANON_KEY")
 
-
+def _get_supabase_anon_key() -> Optional[str]:
+    return os.environ.get("METAFORGE_SUPABASE_ANON_KEY")
 class DownloadError(RuntimeError):
     pass
 

--- a/tests/autoscrapper/progress/test_data_update.py
+++ b/tests/autoscrapper/progress/test_data_update.py
@@ -36,8 +36,13 @@ def test_update_data_snapshot_handles_missing_key(tmp_path):
 
         # Verify it logged warnings for both attempts to fetch from Supabase
         assert mock_log.warning.call_count == 2
-        args, _ = mock_log.warning.call_args_list[0]
-        assert "Skipping crafting component data" in args[0]
-        assert "METAFORGE_SUPABASE_ANON_KEY environment variable is not set" in str(
-            args[1]
+        warning_calls = [call_args for call_args, _ in mock_log.warning.call_args_list]
+        assert any(
+            "Skipping crafting component data" in call_args[0]
+            for call_args in warning_calls
+        )
+        assert any(
+            "METAFORGE_SUPABASE_ANON_KEY environment variable is not set"
+            in " ".join(str(arg) for arg in call_args)
+            for call_args in warning_calls
         )

--- a/tests/autoscrapper/progress/test_data_update.py
+++ b/tests/autoscrapper/progress/test_data_update.py
@@ -36,13 +36,8 @@ def test_update_data_snapshot_handles_missing_key(tmp_path):
 
         # Verify it logged warnings for both attempts to fetch from Supabase
         assert mock_log.warning.call_count == 2
-        warning_calls = [call_args for call_args, _ in mock_log.warning.call_args_list]
-        assert any(
-            "Skipping crafting component data" in call_args[0]
-            for call_args in warning_calls
-        )
-        assert any(
-            "METAFORGE_SUPABASE_ANON_KEY environment variable is not set"
-            in " ".join(str(arg) for arg in call_args)
-            for call_args in warning_calls
+        args, _ = mock_log.warning.call_args_list[0]
+        assert "Skipping crafting component data" in args[0]
+        assert "METAFORGE_SUPABASE_ANON_KEY environment variable is not set" in str(
+            args[1]
         )

--- a/tests/autoscrapper/progress/test_data_update.py
+++ b/tests/autoscrapper/progress/test_data_update.py
@@ -1,0 +1,43 @@
+import pytest
+import unittest.mock as mock
+from autoscrapper.progress.data_update import (
+    _fetch_supabase_all,
+    update_data_snapshot,
+    DownloadError,
+)
+
+
+def test_fetch_supabase_all_missing_key():
+    with mock.patch("autoscrapper.progress.data_update.SUPABASE_ANON_KEY", None):
+        with pytest.raises(
+            DownloadError,
+            match="METAFORGE_SUPABASE_ANON_KEY environment variable is not set",
+        ):
+            _fetch_supabase_all("some_table")
+
+
+def test_update_data_snapshot_handles_missing_key(tmp_path):
+    # Mock _fetch_all_items and _fetch_all_quests to avoid network calls
+    with (
+        mock.patch(
+            "autoscrapper.progress.data_update._fetch_all_items", return_value=[]
+        ),
+        mock.patch(
+            "autoscrapper.progress.data_update._fetch_all_quests", return_value=[]
+        ),
+        mock.patch("autoscrapper.progress.data_update.SUPABASE_ANON_KEY", None),
+        mock.patch("autoscrapper.progress.data_update._log") as mock_log,
+    ):
+        metadata = update_data_snapshot(tmp_path)
+
+        # Verify it continued despite the missing key
+        assert metadata["itemCount"] == 0
+        assert metadata["questCount"] == 0
+
+        # Verify it logged warnings for both attempts to fetch from Supabase
+        assert mock_log.warning.call_count == 2
+        args, _ = mock_log.warning.call_args_list[0]
+        assert "Skipping crafting component data" in args[0]
+        assert "METAFORGE_SUPABASE_ANON_KEY environment variable is not set" in str(
+            args[1]
+        )


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Removed a hardcoded Supabase Anon Key from `src/autoscrapper/progress/data_update.py`.

### ⚠️ Risk: The potential impact if left unfixed
A hardcoded API key in the codebase could be exposed to anyone with access to the source code, potentially leading to unauthorized data access or abuse of the Supabase API.

### 🛡️ Solution: How the fix addresses the vulnerability
- Replaced the hardcoded key with a lookup from the `METAFORGE_SUPABASE_ANON_KEY` environment variable.
- Added a check to ensure that the environment variable is present before attempting to fetch data from Supabase.
- Implemented a new test suite to ensure that the application handles the absence of the key gracefully by logging a warning and continuing with available local data, preventing a hard crash while still informing the user of the missing configuration.


---
*PR created automatically by Jules for task [94267463178063747](https://jules.google.com/task/94267463178063747) started by @Ven0m0*