### PR TITLE
🧹 Fix unused unpacked variable hresult in scan.py

### DIFF
--- a/src/autoscrapper/tui/scan.py
+++ b/src/autoscrapper/tui/scan.py
@@ -107,7 +107,7 @@ def _format_exception_for_ui(exc: BaseException, *, context: str) -> str:
     lines = [context, "", f"{type(exc).__name__}: {exc}"]
     com_details = _com_error_details(exc)
     if com_details is not None:
-        hresult, text, hresult_hex = com_details
+        _, text, hresult_hex = com_details
         lines.append(f"COM error: {hresult_hex} ({text})")
     lines.extend(["", "Traceback:", trace])
     report_path = _write_crash_report("\n".join(lines))


### PR DESCRIPTION
🎯 What:
Changed line 110 in `src/autoscrapper/tui/scan.py` from `hresult, text, hresult_hex = com_details` to `_, text, hresult_hex = com_details`.

💡 Why:
The `hresult` variable was unpacked but never used in the function `_format_exception_for_ui`. Using `_` makes it clear to readers and linters that the variable is intentionally ignored, improving readability and maintainability.

✅ Verification:
Ran the full test suite (`uv run pytest tests/`) and all tests passed. Also ran `uv run ruff check src` which passed without issues.

✨ Result:
Cleaner code with no unused variables while preserving existing functionality.

---
*PR created automatically by Jules for task [4169996971817383695](https://jules.google.com/task/4169996971817383695) started by @Ven0m0*