### PR TITLE
🧪 [Test] Add coverage for enable_ocr_debug exception handling

### DIFF
--- a/tests/autoscrapper/ocr/test_inventory_vision.py
+++ b/tests/autoscrapper/ocr/test_inventory_vision.py
@@ -375,3 +375,26 @@ class TestResetOcrCaches:
         assert _vision._last_roi_hash is None
         assert _vision._last_ocr_result is None
         assert _vision._ITEM_NAMES is None
+
+# ---------------------------------------------------------------------------
+# enable_ocr_debug
+# ---------------------------------------------------------------------------
+
+class TestEnableOcrDebug:
+    def test_enable_ocr_debug_mkdir_exception(self, capsys):
+        """Test that an exception during directory creation is caught and handled."""
+        from pathlib import Path
+
+        mock_path = MagicMock(spec=Path)
+        # Configure the mock to raise an exception when mkdir is called
+        mock_path.mkdir.side_effect = OSError("Permission denied")
+
+        # Call the function
+        _vision.enable_ocr_debug(mock_path)
+
+        # Verify that _OCR_DEBUG_DIR was set to None
+        assert _vision._OCR_DEBUG_DIR is None
+
+        # Verify the exception was caught and an error message was printed
+        captured = capsys.readouterr()
+        assert "[vision_ocr] failed to enable OCR debug dir: Permission denied" in captured.out

--- a/tests/autoscrapper/ocr/test_inventory_vision.py
+++ b/tests/autoscrapper/ocr/test_inventory_vision.py
@@ -386,15 +386,12 @@ class TestEnableOcrDebug:
         from pathlib import Path
 
         mock_path = MagicMock(spec=Path)
-        # Configure the mock to raise an exception when mkdir is called
         mock_path.mkdir.side_effect = OSError("Permission denied")
 
-        # Call the function
-        _vision.enable_ocr_debug(mock_path)
+        # Use patch to isolate global state and verify it is cleared on failure
+        with patch.object(_vision, "_OCR_DEBUG_DIR", Path("/tmp/dummy")):
+            _vision.enable_ocr_debug(mock_path)
+            assert _vision._OCR_DEBUG_DIR is None
 
-        # Verify that _OCR_DEBUG_DIR was set to None
-        assert _vision._OCR_DEBUG_DIR is None
-
-        # Verify the exception was caught and an error message was printed
         captured = capsys.readouterr()
         assert "[vision_ocr] failed to enable OCR debug dir: Permission denied" in captured.out


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `enable_ocr_debug` function handles an `OSError` gracefully if it fails to create a directory, but this specific line wasn't covered by tests.

📊 **Coverage:** What scenarios are now tested
Added `TestEnableOcrDebug.test_enable_ocr_debug_mkdir_exception` which mocks the `Path.mkdir` method to trigger an `OSError`. The test validates that the `_OCR_DEBUG_DIR` remains `None` and the correct warning log is outputted.

✨ **Result:** The improvement in test coverage
Test coverage is improved to properly execute exception handling path for directory creation within `enable_ocr_debug`.

---
*PR created automatically by Jules for task [8398143954020378437](https://jules.google.com/task/8398143954020378437) started by @Ven0m0*