### PR TITLE
🧹 Code health improvement: Update type hints to use built-in types in item_actions.py

### DIFF
--- a/src/autoscrapper/core/item_actions.py
+++ b/src/autoscrapper/core/item_actions.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Tuple, cast
+from typing import Literal, Optional, cast
 
 import orjson
 
 from ..interaction.inventory_grid import Cell
 
 Decision = Literal["KEEP", "RECYCLE", "SELL"]
-DecisionList = List[Decision]
-ActionMap = Dict[str, DecisionList]
+DecisionList = list[Decision]
+ActionMap = dict[str, DecisionList]
 
 
 @dataclass
@@ -124,7 +124,7 @@ def load_item_actions(path: Optional[Path] = None) -> ActionMap:
     return actions
 
 
-def choose_decision(item_name: str, actions: ActionMap) -> Tuple[Optional[Decision], Optional[str]]:
+def choose_decision(item_name: str, actions: ActionMap) -> tuple[Optional[Decision], Optional[str]]:
     normalized = normalize_item_name(item_name)
     if not normalized:
         return None, None


### PR DESCRIPTION
🎯 **What:** Replaced deprecated `typing.Dict`, `typing.List`, and `typing.Tuple` with standard built-in equivalents (`dict`, `list`, `tuple`) in `src/autoscrapper/core/item_actions.py`.
💡 **Why:** Modernizes the codebase to follow standard Python conventions for type hints, improving readability and maintainability.
✅ **Verification:** Ran `ruff format` and `ruff check` (no issues), and successfully executed all unit tests (`uv run pytest tests/autoscrapper/core/test_item_actions.py`).
✨ **Result:** Cleaner and more modern Python code without altering functionality.

---
*PR created automatically by Jules for task [14698069813317090485](https://jules.google.com/task/14698069813317090485) started by @Ven0m0*