### PR TITLE
🧹 Fix unused import Table in rich_support.py

### DIFF
--- a/src/autoscrapper/scanner/rich_support.py
+++ b/src/autoscrapper/scanner/rich_support.py
@@ -1,24 +1,24 @@
 from __future__ import annotations
 
 try:
-    from rich import box
+    from rich import box as box
     from rich.align import Align as Align
-    from rich.console import Console, Group
-    from rich.live import Live
-    from rich.panel import Panel
+    from rich.console import Console as Console, Group as Group
+    from rich.live import Live as Live
+    from rich.panel import Panel as Panel
     from rich.progress import (
-        BarColumn,
-        Progress,
-        ProgressColumn,
-        SpinnerColumn,
-        Task,
-        TaskProgressColumn,
-        TextColumn,
-        TimeElapsedColumn,
-        TimeRemainingColumn,
+        BarColumn as BarColumn,
+        Progress as Progress,
+        ProgressColumn as ProgressColumn,
+        SpinnerColumn as SpinnerColumn,
+        Task as Task,
+        TaskProgressColumn as TaskProgressColumn,
+        TextColumn as TextColumn,
+        TimeElapsedColumn as TimeElapsedColumn,
+        TimeRemainingColumn as TimeRemainingColumn,
     )
-    from rich.table import Table
-    from rich.text import Text
+    from rich.table import Table as Table
+    from rich.text import Text as Text
 except ImportError:  # pragma: no cover - optional dependency
     Align = None
     Console = None


### PR DESCRIPTION
🎯 **What:** Resolved the unused import warning for `Table` in `src/autoscrapper/scanner/rich_support.py`.
💡 **Why:** `rich_support.py` acts as a centralized shim for optional `rich` components. By using the explicit `import as Name` syntax, we signal to linters like Ruff that these imports are intended for re-export, even if not used locally. This preserves the architectural pattern of having a single place for optional dependency handling while cleaning up linting noise.
✅ **Verification:**
- Ran `ruff check` on `rich_support.py` and confirmed no F401 (unused import) errors.
- Ran scanner unit tests (`tests/autoscrapper/scanner/`) and confirmed all 28 tests passed.
- Verified that `report.py` and `live_ui.py` still correctly import components from `rich_support.py`.
✨ **Result:** Improved code health by resolving linting issues without fragmenting the optional dependency logic across the codebase.

---
*PR created automatically by Jules for task [4902344614495996330](https://jules.google.com/task/4902344614495996330) started by @Ven0m0*