### PR TITLE
🧹 Fix unused import in rich_support.py and bug in config.py

### DIFF
--- a/src/autoscrapper/config.py
+++ b/src/autoscrapper/config.py
@@ -183,7 +183,7 @@ def _load_config_dict() -> Dict[str, Any]:
         raw = orjson.loads(path.read_bytes())
     except FileNotFoundError:
         return {}
-    except (OSError, json.JSONDecodeError) as e:
+    except (OSError, orjson.JSONDecodeError) as e:
         _log.warning("config: failed to load config file: %s", e)
         return {}
 

--- a/src/autoscrapper/scanner/rich_support.py
+++ b/src/autoscrapper/scanner/rich_support.py
@@ -17,7 +17,7 @@ try:
         TimeElapsedColumn,
         TimeRemainingColumn,
     )
-    from rich.table import Table
+    from rich.table import Table as Table
     from rich.text import Text
 except ImportError:  # pragma: no cover - optional dependency
     Align = None


### PR DESCRIPTION
🎯 **What:**
- Resolved the unused import warning for `Table` in `src/autoscrapper/scanner/rich_support.py`.
- Fixed a bug in `src/autoscrapper/config.py` where `json.JSONDecodeError` was referenced instead of `orjson.JSONDecodeError`.

💡 **Why:**
- `rich_support.py` is a shim for optional dependencies. The `as Table` syntax clarifies it's an intended export for other modules.
- The `config.py` fix was necessary as `json` was not imported and `orjson` is the actual JSON library used in that file.

✅ **Verification:**
- `ruff check src/` passes cleanly.
- `pytest tests/autoscrapper/scanner/` passes all 28 tests.
- Verified `config.py` fix addresses the CI failure.

---
*PR created automatically by Jules for task [4902344614495996330](https://jules.google.com/task/4902344614495996330) started by @Ven0m0*