### PR TITLE
🧹 Fix unused run_tui import in autoscrapper/tui/__init__.py

### DIFF
--- a/src/autoscrapper/__main__.py
+++ b/src/autoscrapper/__main__.py
@@ -4,7 +4,7 @@ import sys
 
 
 def _run_tui() -> int:
-    from .tui import run_tui
+    from .tui.app import run_tui
 
     return run_tui()
 

--- a/src/autoscrapper/scanner/cli.py
+++ b/src/autoscrapper/scanner/cli.py
@@ -20,6 +20,6 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: Optional[Iterable[str]] = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
-    from ..tui import run_tui
+    from ..tui.app import run_tui
 
     return run_tui(start_screen="scan", dry_run=args.dry_run)

--- a/src/autoscrapper/tui/__init__.py
+++ b/src/autoscrapper/tui/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations

--- a/src/autoscrapper/tui/__init__.py
+++ b/src/autoscrapper/tui/__init__.py
@@ -1,5 +1,1 @@
 from __future__ import annotations
-
-from .app import run_tui
-
-__all__ = ["run_tui"]


### PR DESCRIPTION
🎯 **What:** Removed unused `run_tui` import and `__all__` export from `src/autoscrapper/tui/__init__.py`. Updated call sites in `__main__.py` and `scanner/cli.py` to import directly from `autoscrapper.tui.app`.
💡 **Why:** Cleans up the namespace and resolves Ruff linting warnings/unused import clutter, improving overall codebase maintainability.
✅ **Verification:** Verified via `uv run ruff check src/autoscrapper/` (which passed) and `uv run pytest tests/autoscrapper/` to ensure no regression functionality.
✨ **Result:** A cleaner `__init__.py` file without affecting application usage.

---
*PR created automatically by Jules for task [9686683207741537324](https://jules.google.com/task/9686683207741537324) started by @Ven0m0*