### PR TITLE
Add module-level cache to ocr_item_name

### DIFF
--- a/src/autoscrapper/ocr/inventory_vision.py
+++ b/src/autoscrapper/ocr/inventory_vision.py
@@ -1003,11 +1003,7 @@ def _extract_action_line_bbox(
     indices = [
         i
         for i in range(n)
-        if page_nums[i] == bp
-        and block_nums[i] == bb
-        and par_nums[i] == bpa
-        and line_nums[i] == bl
-        and widths[i] > 0
+        if page_nums[i] == bp and block_nums[i] == bb and par_nums[i] == bpa and line_nums[i] == bl and widths[i] > 0
     ]
     # If every word on the line has width==0 (degenerate tesserocr output), fall
     # back to the original group indices so min/max never operate on empty lists.
@@ -1291,16 +1287,28 @@ def ocr_item_name(roi_bgr: np.ndarray) -> str:
     if roi_bgr.size == 0:
         return ""
 
+    global _last_ocr_result, _last_roi_hash
+    roi_hash = _hash_roi(roi_bgr)
+    if _last_roi_hash == roi_hash and _last_ocr_result is not None:
+        return _last_ocr_result[0]
+
     processed = preprocess_for_ocr(roi_bgr)
     try:
         raw = image_to_string(processed, single_line=True)
     except Exception as exc:
+        _last_roi_hash = None  # invalidate cache so next call does not re-serve stale result
         print(
             f"[vision_ocr] ocr_backend image_to_string failed for item name; falling back to empty result. error={exc}",
             flush=True,
         )
         return ""
-    return match_item_name(raw)
+
+    item_name = match_item_name(raw)
+    if item_name:
+        _last_roi_hash = roi_hash
+        _last_ocr_result = (item_name, raw)
+
+    return item_name
 
 
 def ocr_inventory_count(roi_bgr: np.ndarray) -> Tuple[Optional[int], str]:

--- a/tests/autoscrapper/ocr/test_inventory_vision.py
+++ b/tests/autoscrapper/ocr/test_inventory_vision.py
@@ -319,7 +319,7 @@ class TestOcrTitleStripCache:
         """
         reset_ocr_caches()
         img = self._make_image()
-           # no words → item_name will be ""
+        # no words → item_name will be ""
 
         with (
             patch.object(_vision, "image_to_string", return_value="") as mock_ocr,
@@ -338,7 +338,6 @@ class TestOcrTitleStripCache:
         """When item_name is non-empty, the second call must use the cache."""
         reset_ocr_caches()
         img = self._make_image()
-
 
         with (
             patch.object(_vision, "image_to_string", return_value="FoundItem") as mock_ocr,
@@ -359,6 +358,45 @@ class TestOcrTitleStripCache:
 
 
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# ocr_item_name — cache tests
+# ---------------------------------------------------------------------------
+
+
+class TestOcrItemNameCache:
+    def _make_image(self):
+        return _solid_bgr(30, 100)
+
+    def test_empty_result_not_cached(self):
+        reset_ocr_caches()
+        img = self._make_image()
+
+        with patch.object(_vision, "image_to_string", return_value="") as mock_ocr:
+            _vision.ocr_item_name(img)
+            _vision.ocr_item_name(img)
+
+        assert mock_ocr.call_count == 2, "image_to_string should be called twice when the first result was empty"
+
+    def test_non_empty_result_is_cached(self):
+        reset_ocr_caches()
+        img = self._make_image()
+
+        with (
+            patch.object(_vision, "image_to_string", return_value="FoundItem") as mock_ocr,
+            patch.object(
+                _vision,
+                "match_item_name",
+                return_value="Arc Alloy",
+            ),
+        ):
+            _vision.ocr_item_name(img)
+            _vision.ocr_item_name(img)
+
+        assert mock_ocr.call_count == 1, "image_to_string should only be called once when result was cached"
+
+
 # reset_ocr_caches
 # ---------------------------------------------------------------------------
 
@@ -376,9 +414,11 @@ class TestResetOcrCaches:
         assert _vision._last_ocr_result is None
         assert _vision._ITEM_NAMES is None
 
+
 # ---------------------------------------------------------------------------
 # enable_ocr_debug
 # ---------------------------------------------------------------------------
+
 
 class TestEnableOcrDebug:
     def test_enable_ocr_debug_mkdir_exception(self, capsys):


### PR DESCRIPTION
Implemented the `_last_roi_hash` and `_last_ocr_result` caching logic in `ocr_item_name` inside `inventory_vision.py` to skip redundant OCR operations for identical pre-cropped title strips. Added corresponding cache hit/miss tests in `test_inventory_vision.py`.

---
*PR created automatically by Jules for task [5516655562828234831](https://jules.google.com/task/5516655562828234831) started by @Ven0m0*