### PR TITLE
🧹 fix: Add noqa to unused Text import in rich_support

### DIFF
--- a/src/autoscrapper/scanner/rich_support.py
+++ b/src/autoscrapper/scanner/rich_support.py
@@ -18,7 +18,7 @@ try:
         TimeRemainingColumn as TimeRemainingColumn,
     )
     from rich.table import Table as Table
-    from rich.text import Text as Text
+    from rich.text import Text as Text  # noqa: F401
 except ImportError:  # pragma: no cover - optional dependency
     Align = None
     Console = None


### PR DESCRIPTION
🎯 **What:** The `Text` import in `src/autoscrapper/scanner/rich_support.py` was being flagged as unused, but it was actually serving as a compatibility shim for `Text` across several scanner files like `live_ui.py` and `report.py` when `rich` isn't installed. 
💡 **Why:** Removing the import entirely broke type definitions in `mypy` and fallback capabilities. Adding `# noqa: F401` suppresses the linting error while safely keeping the compatibility shim functioning properly for dependent UI files.
✅ **Verification:** Verified by running `pytest tests/autoscrapper/scanner`, `ruff check src/autoscrapper/scanner/rich_support.py`, and `mypy` natively. All test suites pass without new issues.
✨ **Result:** Cleaned up linting errors without removing needed functional shims.

---
*PR created automatically by Jules for task [4524795858957794469](https://jules.google.com/task/4524795858957794469) started by @Ven0m0*