### PR TITLE
🧪 Add unit tests for choose_decision in item_actions

### DIFF
--- a/tests/autoscrapper/core/test_item_actions.py
+++ b/tests/autoscrapper/core/test_item_actions.py
@@ -3,6 +3,7 @@ from autoscrapper.core.item_actions import (
     normalize_item_name,
     clean_ocr_text,
     _normalize_action,
+    choose_decision,
 )
 
 
@@ -56,3 +57,23 @@ def test_clean_ocr_text(raw, expected):
 )
 def test__normalize_action(value, expected):
     assert _normalize_action(value) == expected
+
+
+@pytest.mark.parametrize(
+    "item_name, actions, expected",
+    [
+        # Empty/whitespace item name
+        ("", {"item": ["KEEP"]}, (None, None)),
+        ("   ", {"item": ["KEEP"]}, (None, None)),
+        # Item not in actions map
+        ("unknown item", {"known item": ["KEEP"]}, (None, None)),
+        # Item in actions map with 1 decision
+        ("known item", {"known item": ["KEEP"]}, ("KEEP", None)),
+        # Item in actions map with >1 decisions
+        ("known item", {"known item": ["KEEP", "SELL"]}, ("KEEP", "Multiple decisions ['KEEP', 'SELL']; chose KEEP.")),
+        # Item case-insensitive matching / extra whitespace
+        ("  Known Item  ", {"known item": ["SELL"]}, ("SELL", None)),
+    ],
+)
+def test_choose_decision(item_name, actions, expected):
+    assert choose_decision(item_name, actions) == expected


### PR DESCRIPTION
🎯 **What:** The testing gap in `choose_decision` function of `src/autoscrapper/core/item_actions.py` was addressed. This function was previously untested.
📊 **Coverage:** The new test `test_choose_decision` covers various scenarios including:
- Empty or whitespace-only item names.
- Items not found in the actions map.
- Items found in the actions map with a single decision.
- Items found in the actions map with multiple decisions (verifying the note formatting).
- Case-insensitive and whitespace-insensitive matching.
✨ **Result:** Increased unit test coverage and confidence when refactoring decision logic. The test suite passes fully without any regressions related to this module.

---
*PR created automatically by Jules for task [12835403878971749033](https://jules.google.com/task/12835403878971749033) started by @Ven0m0*