### PR TITLE
🧪 Add missing error path test for load_item_actions

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,7 +1,0 @@
-🧪 Add missing error path test for `load_item_actions`
-
-🎯 **What:** This PR addresses a testing gap in `src/autoscrapper/core/item_actions.py:77` by explicitly verifying that `load_item_actions` returns an empty dictionary `{}` when the items rules file does not exist (`FileNotFoundError`).
-
-📊 **Coverage:** Adds coverage for the missing file scenario. We use `unittest.mock.patch` to simulate `pathlib.Path.read_bytes` raising a `FileNotFoundError`, effectively testing the `try/except` block and error handling logic directly.
-
-✨ **Result:** Increased testing confidence around the error-handling fallback logic, preventing future regressions in configuration file processing.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,7 @@
+🧪 Add missing error path test for `load_item_actions`
+
+🎯 **What:** This PR addresses a testing gap in `src/autoscrapper/core/item_actions.py:77` by explicitly verifying that `load_item_actions` returns an empty dictionary `{}` when the items rules file does not exist (`FileNotFoundError`).
+
+📊 **Coverage:** Adds coverage for the missing file scenario. We use `unittest.mock.patch` to simulate `pathlib.Path.read_bytes` raising a `FileNotFoundError`, effectively testing the `try/except` block and error handling logic directly.
+
+✨ **Result:** Increased testing confidence around the error-handling fallback logic, preventing future regressions in configuration file processing.

--- a/tests/autoscrapper/core/test_item_actions.py
+++ b/tests/autoscrapper/core/test_item_actions.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
 from autoscrapper.core.item_actions import (
     normalize_item_name,
     clean_ocr_text,

--- a/tests/autoscrapper/core/test_item_actions.py
+++ b/tests/autoscrapper/core/test_item_actions.py
@@ -1,8 +1,10 @@
 import pytest
+from unittest.mock import patch
 from autoscrapper.core.item_actions import (
     normalize_item_name,
     clean_ocr_text,
     _normalize_action,
+    load_item_actions,
 )
 
 
@@ -56,3 +58,12 @@ def test_clean_ocr_text(raw, expected):
 )
 def test__normalize_action(value, expected):
     assert _normalize_action(value) == expected
+
+
+@patch("pathlib.Path.read_bytes")
+def test_load_item_actions_file_not_found(mock_read_bytes):
+    mock_read_bytes.side_effect = FileNotFoundError()
+
+    result = load_item_actions()
+
+    assert result == {}


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap in `src/autoscrapper/core/item_actions.py:77` by explicitly verifying that `load_item_actions` returns an empty dictionary `{}` when the items rules file does not exist (`FileNotFoundError`).

📊 **Coverage:** Adds coverage for the missing file scenario. We use `unittest.mock.patch` to simulate `pathlib.Path.read_bytes` raising a `FileNotFoundError`, effectively testing the `try/except` block and error handling logic directly.

✨ **Result:** Increased testing confidence around the error-handling fallback logic, preventing future regressions in configuration file processing.

---
*PR created automatically by Jules for task [3370809232566106377](https://jules.google.com/task/3370809232566106377) started by @Ven0m0*