### PR TITLE
Merge PRs #90, #107, #108, #110, #117, #120, #124, #136 with review suggestions

### DIFF
--- a/src/autoscrapper/interaction/ui_windows.py
+++ b/src/autoscrapper/interaction/ui_windows.py
@@ -15,6 +15,7 @@ from .inventory_grid import Cell
 from . import input_driver as pdi
 from .keybinds import DEFAULT_STOP_KEY
 
+
 # Target window
 def _default_target_app() -> str:
     if sys.platform.startswith("linux"):

--- a/src/autoscrapper/ocr/inventory_vision.py
+++ b/src/autoscrapper/ocr/inventory_vision.py
@@ -827,7 +827,7 @@ def enable_ocr_debug(debug_dir: Path) -> None:
         debug_dir.mkdir(parents=True, exist_ok=True)
         _OCR_DEBUG_DIR = debug_dir
         print(f"[vision_ocr] OCR debug output enabled at {_OCR_DEBUG_DIR}", flush=True)
-    except Exception as exc:  # pragma: no cover - filesystem dependent
+    except Exception as exc:
         print(f"[vision_ocr] failed to enable OCR debug dir: {exc}", flush=True)
         _OCR_DEBUG_DIR = None
 
@@ -1029,7 +1029,7 @@ def find_action_bbox_by_ocr(
     processed = preprocess_for_ocr(infobox_bgr, restrict_otsu_to_left=True)
     try:
         data = image_to_data(processed)
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover - OCR-backend dependent
         print(
             f"[vision_ocr] ocr_backend image_to_data failed for target={target}; falling back to no bbox. error={exc}",
             flush=True,
@@ -1098,7 +1098,7 @@ def ocr_title_strip(title_strip_bgr: np.ndarray) -> InfoboxOcrResult:
         ocr_start = time.perf_counter()
         raw_text = image_to_string(processed, single_line=True)
         ocr_time = time.perf_counter() - ocr_start
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover - OCR backend dependent
         _last_roi_hash = None  # invalidate cache so next call does not re-serve stale result
         print(
             f"[vision_ocr] ocr_backend image_to_string failed for infobox title strip; "
@@ -1178,7 +1178,7 @@ def ocr_context_menu(context_crop_bgr: np.ndarray) -> InfoboxOcrResult:
         ocr_start = time.perf_counter()
         data = image_to_data(processed)
         ocr_time = time.perf_counter() - ocr_start
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover - OCR backend failure path
         print(
             f"[vision_ocr] ocr_backend image_to_data failed for context menu; "
             f"falling back to empty OCR result. error={exc}",
@@ -1294,7 +1294,7 @@ def ocr_item_name(roi_bgr: np.ndarray) -> str:
     processed = preprocess_for_ocr(roi_bgr)
     try:
         raw = image_to_string(processed, single_line=True)
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover - OCR backend dependent
         _last_roi_hash = None  # invalidate cache so next call does not re-serve stale result
         print(
             f"[vision_ocr] ocr_backend image_to_string failed for item name; falling back to empty result. error={exc}",
@@ -1323,7 +1323,7 @@ def ocr_inventory_count(roi_bgr: np.ndarray) -> Tuple[Optional[int], str]:
 
     try:
         raw = image_to_string(processed)
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover - OCR backend dependent
         print(
             f"[vision_ocr] ocr_backend image_to_string failed for inventory count: {exc}",
             flush=True,

--- a/src/autoscrapper/progress/data_update.py
+++ b/src/autoscrapper/progress/data_update.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import concurrent.futures
 import io
 import logging
 import os
@@ -62,27 +63,78 @@ def _fetch_json(url: str, headers: Optional[Dict[str, str]] = None) -> object:
 
 def _fetch_metaforge_collection(resource: str) -> List[dict]:
     rows: List[dict] = []
-    current_page = 1
-    has_next = True
     limit = 100
 
-    while has_next:
-        t0 = time.monotonic()
-        url = f"{METAFORGE_API_BASE}/{resource}?page={current_page}&limit={limit}"
-        response = _fetch_json(url)
-        if not isinstance(response, dict):
-            raise DownloadError(f"Unexpected response for {resource}")
-        data = response.get("data") or []
-        if not isinstance(data, list):
-            raise DownloadError(f"Unexpected {resource} payload: data must be a list")
-        rows.extend(entry for entry in data if isinstance(entry, dict))
-        pagination = response.get("pagination") or {}
-        has_next = bool(pagination.get("hasNextPage"))
-        current_page += 1
-        if has_next:
-            elapsed = time.monotonic() - t0
-            if elapsed < 0.1:
-                time.sleep(0.1 - elapsed)
+    url = f"{METAFORGE_API_BASE}/{resource}?page=1&limit={limit}"
+    response = _fetch_json(url)
+    if not isinstance(response, dict):
+        raise DownloadError(f"Unexpected response for {resource}")
+    data = response.get("data") or []
+    if not isinstance(data, list):
+        raise DownloadError(f"Unexpected {resource} payload: data must be a list")
+    rows.extend(entry for entry in data if isinstance(entry, dict))
+
+    pagination = response.get("pagination") or {}
+    if not isinstance(pagination, dict):
+        raise DownloadError(f"Unexpected {resource} payload: pagination must be an object")
+
+    raw_total_pages = pagination.get("totalPages")
+    total_pages: Optional[int]
+    if raw_total_pages is None:
+        total_pages = None
+    elif isinstance(raw_total_pages, bool):
+        raise DownloadError(f"Unexpected {resource} payload: totalPages must be an integer")
+    elif isinstance(raw_total_pages, int):
+        total_pages = raw_total_pages
+    elif isinstance(raw_total_pages, str):
+        try:
+            total_pages = int(raw_total_pages)
+        except ValueError as exc:
+            raise DownloadError(f"Unexpected {resource} payload: totalPages must be an integer") from exc
+    else:
+        raise DownloadError(f"Unexpected {resource} payload: totalPages must be an integer")
+
+    if total_pages is not None and total_pages > 1:
+
+        def fetch_page(page: int) -> List[dict]:
+            page_url = f"{METAFORGE_API_BASE}/{resource}?page={page}&limit={limit}"
+            try:
+                page_response = _fetch_json(page_url)
+                if not isinstance(page_response, dict):
+                    raise DownloadError(f"Unexpected response for {resource} on page {page} ({page_url})")
+                page_data = page_response.get("data") or []
+                if not isinstance(page_data, list):
+                    raise DownloadError(
+                        f"Unexpected {resource} payload on page {page} ({page_url}): data must be a list"
+                    )
+                return [entry for entry in page_data if isinstance(entry, dict)]
+            except DownloadError:
+                raise
+            except Exception as exc:
+                raise DownloadError(f"Failed to fetch {resource} page {page} ({page_url})") from exc
+
+        max_workers = min(10, total_pages - 1)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            for page_rows in executor.map(fetch_page, range(2, total_pages + 1)):
+                rows.extend(page_rows)
+    elif pagination.get("hasNextPage"):
+        # Fallback to sequential if totalPages is not available
+        current_page = 2
+        has_next = True
+        while has_next:
+            url = f"{METAFORGE_API_BASE}/{resource}?page={current_page}&limit={limit}"
+            response = _fetch_json(url)
+            if not isinstance(response, dict):
+                raise DownloadError(f"Unexpected response for {resource} on page {current_page} ({url})")
+            data = response.get("data") or []
+            if not isinstance(data, list):
+                raise DownloadError(
+                    f"Unexpected {resource} payload on page {current_page} ({url}): data must be a list"
+                )
+            rows.extend(entry for entry in data if isinstance(entry, dict))
+            pagination = response.get("pagination") or {}
+            has_next = bool(pagination.get("hasNextPage"))
+            current_page += 1
 
     return rows
 

--- a/src/autoscrapper/scanner/actions.py
+++ b/src/autoscrapper/scanner/actions.py
@@ -213,5 +213,3 @@ def resolve_action_taken(
             context=context,
         )
     return "SCAN_ONLY"
-
-

--- a/tests/autoscrapper/core/test_item_actions.py
+++ b/tests/autoscrapper/core/test_item_actions.py
@@ -4,6 +4,7 @@ from autoscrapper.core.item_actions import (
     clean_ocr_text,
     _normalize_action,
     choose_decision,
+    load_item_actions,
 )
 
 
@@ -77,3 +78,9 @@ def test__normalize_action(value, expected):
 )
 def test_choose_decision(item_name, actions, expected):
     assert choose_decision(item_name, actions) == expected
+
+
+def test_load_item_actions_file_not_found(tmp_path):
+    missing_path = tmp_path / "missing.json"
+    result = load_item_actions(path=missing_path)
+    assert result == {}

--- a/tests/autoscrapper/items/test_rules_store.py
+++ b/tests/autoscrapper/items/test_rules_store.py
@@ -8,6 +8,7 @@ from autoscrapper.items.rules_store import (
     DEFAULT_RULES_PATH,
 )
 
+
 @pytest.mark.parametrize(
     "value, expected",
     [
@@ -32,20 +33,24 @@ from autoscrapper.items.rules_store import (
 def test_normalize_action(value, expected):
     assert normalize_action(value) == expected
 
+
 @patch("pathlib.Path.exists")
 def test_active_rules_path_custom_exists(mock_exists):
     mock_exists.return_value = True
     assert active_rules_path() == CUSTOM_RULES_PATH
+
 
 @patch("pathlib.Path.exists")
 def test_active_rules_path_custom_missing(mock_exists):
     mock_exists.return_value = False
     assert active_rules_path() == DEFAULT_RULES_PATH
 
+
 @patch("pathlib.Path.exists")
 def test_using_custom_rules_true(mock_exists):
     mock_exists.return_value = True
     assert using_custom_rules() is True
+
 
 @patch("pathlib.Path.exists")
 def test_using_custom_rules_false(mock_exists):

--- a/tests/autoscrapper/ocr/test_inventory_vision.py
+++ b/tests/autoscrapper/ocr/test_inventory_vision.py
@@ -415,13 +415,23 @@ class TestResetOcrCaches:
         assert _vision.rules_store._ITEM_NAMES is None
 
 
-
 # ---------------------------------------------------------------------------
 # enable_ocr_debug
 # ---------------------------------------------------------------------------
 
 
 class TestEnableOcrDebug:
+    def test_enable_ocr_debug_success(self, tmp_path):
+        """Test that enable_ocr_debug sets the debug directory and creates it."""
+        debug_dir = tmp_path / "ocr_debug"
+        original_dir = _vision._OCR_DEBUG_DIR
+        try:
+            _vision.enable_ocr_debug(debug_dir)
+            assert _vision._OCR_DEBUG_DIR == debug_dir
+            assert debug_dir.exists()
+        finally:
+            _vision._OCR_DEBUG_DIR = original_dir
+
     def test_enable_ocr_debug_mkdir_exception(self, capsys):
         """Test that an exception during directory creation is caught and handled."""
         from pathlib import Path

--- a/tests/autoscrapper/ocr/test_tesseract.py
+++ b/tests/autoscrapper/ocr/test_tesseract.py
@@ -51,7 +51,7 @@ def test_has_eng_returns_false_if_not_dir(tmp_path):
 
 @patch.dict(os.environ, {"TESSDATA_PREFIX": "/mock/env/path", "APPDATA": "/mock/appdata"})
 @patch("tessdata.data_path", return_value="/mock/tessdata/path")
-@patch("src.autoscrapper.ocr.tesseract.tessdata.__file__", "/mock/pkg/tessdata/__init__.py")
+@patch("autoscrapper.ocr.tesseract.tessdata.__file__", "/mock/pkg/tessdata/__init__.py")
 def test_candidate_tessdata_paths_order(mock_tessdata_path):
     paths = tesseract._candidate_tessdata_paths()
 
@@ -64,9 +64,9 @@ def test_candidate_tessdata_paths_order(mock_tessdata_path):
     assert paths[4] == Path(f"/mock/appdata/Python/{py_ver}/share/tessdata")
 
 
-@patch("src.autoscrapper.ocr.tesseract._has_eng", return_value=True)
-@patch("src.autoscrapper.ocr.tesseract._candidate_tessdata_paths", return_value=[Path("/mock/path")])
-@patch("src.autoscrapper.ocr.tesseract.PyTessBaseAPI")
+@patch("autoscrapper.ocr.tesseract._has_eng", return_value=True)
+@patch("autoscrapper.ocr.tesseract._candidate_tessdata_paths", return_value=[Path("/mock/path")])
+@patch("autoscrapper.ocr.tesseract.PyTessBaseAPI")
 def test_create_api_success(mock_api_class, mock_paths, mock_has_eng):
     mock_api_instance = MagicMock()
     mock_api_class.return_value = mock_api_instance
@@ -79,9 +79,9 @@ def test_create_api_success(mock_api_class, mock_paths, mock_has_eng):
     assert tesseract._tessdata_dir == "/mock/path"
 
 
-@patch("src.autoscrapper.ocr.tesseract._has_eng", return_value=True)
-@patch("src.autoscrapper.ocr.tesseract._candidate_tessdata_paths", return_value=[Path("/mock/path")])
-@patch("src.autoscrapper.ocr.tesseract.PyTessBaseAPI", side_effect=Exception("mock init error"))
+@patch("autoscrapper.ocr.tesseract._has_eng", return_value=True)
+@patch("autoscrapper.ocr.tesseract._candidate_tessdata_paths", return_value=[Path("/mock/path")])
+@patch("autoscrapper.ocr.tesseract.PyTessBaseAPI", side_effect=Exception("mock init error"))
 def test_create_api_fails_all_candidates(mock_api_class, mock_paths, mock_has_eng):
     with pytest.raises(RuntimeError) as exc_info:
         tesseract._create_api()
@@ -125,7 +125,7 @@ def test_as_pil_image_raises_value_error_for_invalid_shape():
         tesseract._as_pil_image(img_invalid)
 
 
-@patch("src.autoscrapper.ocr.tesseract._get_api")
+@patch("autoscrapper.ocr.tesseract._get_api")
 def test_image_to_string_success(mock_get_api):
     mock_api = MagicMock()
     mock_api.GetUTF8Text.return_value = "Mock Text"
@@ -139,7 +139,7 @@ def test_image_to_string_success(mock_get_api):
     mock_api.GetUTF8Text.assert_called_once()
 
 
-@patch("src.autoscrapper.ocr.tesseract._get_api")
+@patch("autoscrapper.ocr.tesseract._get_api")
 def test_image_to_string_empty(mock_get_api):
     mock_api = MagicMock()
     mock_api.GetUTF8Text.return_value = None
@@ -151,7 +151,7 @@ def test_image_to_string_empty(mock_get_api):
     assert text == ""
 
 
-@patch("src.autoscrapper.ocr.tesseract._get_api")
+@patch("autoscrapper.ocr.tesseract._get_api")
 def test_image_to_data_empty_iterator(mock_get_api):
     mock_api = MagicMock()
     mock_api.GetIterator.return_value = None
@@ -173,7 +173,7 @@ def test_build_data_dict_with_iterator():
     mock_word.GetUTF8Text.return_value = "TestWord"
 
     # We need iterate_level to yield our mock word
-    with patch("src.autoscrapper.ocr.tesseract.iterate_level", return_value=[mock_word]):
+    with patch("autoscrapper.ocr.tesseract.iterate_level", return_value=[mock_word]):
         data = tesseract._build_data_dict(MagicMock())
 
         assert len(data["text"]) == 1
@@ -215,9 +215,9 @@ def test_record_backend_info_no_version_attr():
     assert info.tesseract_version == ""
 
 
-@patch("src.autoscrapper.ocr.tesseract._get_api")
-@patch("src.autoscrapper.ocr.tesseract._get_api_line")
-@patch("src.autoscrapper.ocr.tesseract._record_backend_info")
+@patch("autoscrapper.ocr.tesseract._get_api")
+@patch("autoscrapper.ocr.tesseract._get_api_line")
+@patch("autoscrapper.ocr.tesseract._record_backend_info")
 def test_initialize_ocr(mock_record, mock_get_line, mock_get):
     mock_api = MagicMock()
     mock_get.return_value = mock_api
@@ -234,8 +234,8 @@ def test_initialize_ocr(mock_record, mock_get_line, mock_get):
     mock_record.assert_called_once_with(mock_api)
 
 
-@patch("src.autoscrapper.ocr.tesseract._create_api")
-@patch("src.autoscrapper.ocr.tesseract._record_backend_info")
+@patch("autoscrapper.ocr.tesseract._create_api")
+@patch("autoscrapper.ocr.tesseract._record_backend_info")
 def test_get_api_creates_instance(mock_record, mock_create):
     mock_api = MagicMock()
     mock_create.return_value = mock_api
@@ -247,8 +247,8 @@ def test_get_api_creates_instance(mock_record, mock_create):
     mock_record.assert_called_once_with(mock_api)
 
 
-@patch("src.autoscrapper.ocr.tesseract._create_api")
-@patch("src.autoscrapper.ocr.tesseract._record_backend_info")
+@patch("autoscrapper.ocr.tesseract._create_api")
+@patch("autoscrapper.ocr.tesseract._record_backend_info")
 def test_get_api_line_creates_instance(mock_record, mock_create):
     mock_api = MagicMock()
     mock_create.return_value = mock_api
@@ -260,7 +260,7 @@ def test_get_api_line_creates_instance(mock_record, mock_create):
     mock_record.assert_called_once_with(mock_api)
 
 
-@patch("src.autoscrapper.ocr.tesseract._get_api_line")
+@patch("autoscrapper.ocr.tesseract._get_api_line")
 def test_image_to_string_single_line(mock_get_api_line):
     mock_api = MagicMock()
     mock_api.GetUTF8Text.return_value = "Line Text"
@@ -273,7 +273,7 @@ def test_image_to_string_single_line(mock_get_api_line):
     mock_api.SetImage.assert_called_once()
 
 
-@patch("src.autoscrapper.ocr.tesseract._get_api_line")
+@patch("autoscrapper.ocr.tesseract._get_api_line")
 def test_image_to_data_single_line(mock_get_api_line):
     mock_api = MagicMock()
     mock_api.GetIterator.return_value = None
@@ -297,8 +297,8 @@ def test_record_backend_info_already_set():
     mock_api.Version.assert_not_called()
 
 
-@patch("src.autoscrapper.ocr.tesseract._get_api_line")
-@patch("src.autoscrapper.ocr.tesseract._get_api")
+@patch("autoscrapper.ocr.tesseract._get_api_line")
+@patch("autoscrapper.ocr.tesseract._get_api")
 def test_image_to_data_with_iterator(mock_get_api, mock_get_api_line):
     # This tests the full path from image_to_data down to _build_data_dict
     mock_api = MagicMock()
@@ -317,7 +317,7 @@ def test_image_to_data_with_iterator(mock_get_api, mock_get_api_line):
 
     img = np.zeros((10, 10), dtype=np.uint8)
 
-    with patch("src.autoscrapper.ocr.tesseract.iterate_level", return_value=[mock_word]):
+    with patch("autoscrapper.ocr.tesseract.iterate_level", return_value=[mock_word]):
         data = tesseract.image_to_data(img)
 
     assert data["text"][0] == "TestWord"
@@ -335,7 +335,7 @@ def test_build_data_dict_no_bbox():
     mock_word.Confidence.return_value = 95.5
     mock_word.GetUTF8Text.return_value = "TestWord"
 
-    with patch("src.autoscrapper.ocr.tesseract.iterate_level", return_value=[mock_word]):
+    with patch("autoscrapper.ocr.tesseract.iterate_level", return_value=[mock_word]):
         data = tesseract._build_data_dict(MagicMock())
 
         # Word should be skipped if bbox is None
@@ -351,7 +351,7 @@ def test_build_data_dict_none_confidence():
     mock_word.Confidence.return_value = None
     mock_word.GetUTF8Text.return_value = "TestWord"
 
-    with patch("src.autoscrapper.ocr.tesseract.iterate_level", return_value=[mock_word]):
+    with patch("autoscrapper.ocr.tesseract.iterate_level", return_value=[mock_word]):
         data = tesseract._build_data_dict(MagicMock())
 
         assert len(data["text"]) == 1
@@ -367,7 +367,7 @@ def test_build_data_dict_none_text():
     mock_word.Confidence.return_value = 95.5
     mock_word.GetUTF8Text.return_value = None
 
-    with patch("src.autoscrapper.ocr.tesseract.iterate_level", return_value=[mock_word]):
+    with patch("autoscrapper.ocr.tesseract.iterate_level", return_value=[mock_word]):
         data = tesseract._build_data_dict(MagicMock())
 
         assert len(data["text"]) == 1
@@ -391,15 +391,15 @@ def test_get_api_line_already_initialized():
 def test_candidate_tessdata_paths_exception_in_tessdata_data_path():
     with patch.dict(os.environ, clear=True):
         with patch("tessdata.data_path", side_effect=Exception("mock error")):
-            with patch("src.autoscrapper.ocr.tesseract.tessdata.__file__", "/mock/pkg/tessdata/__init__.py"):
+            with patch("autoscrapper.ocr.tesseract.tessdata.__file__", "/mock/pkg/tessdata/__init__.py"):
                 paths = tesseract._candidate_tessdata_paths()
 
                 # Should not include tessdata.data_path since it threw an exception
                 assert Path("/mock/pkg/share/tessdata") in paths
 
 
-@patch("src.autoscrapper.ocr.tesseract._get_api")
-@patch("src.autoscrapper.ocr.tesseract._get_api_line")
+@patch("autoscrapper.ocr.tesseract._get_api")
+@patch("autoscrapper.ocr.tesseract._get_api_line")
 def test_image_to_string_exception(mock_get_api_line, mock_get_api):
     mock_api = MagicMock()
     mock_api.GetUTF8Text.side_effect = Exception("OCR failed")
@@ -410,8 +410,8 @@ def test_image_to_string_exception(mock_get_api_line, mock_get_api):
         tesseract.image_to_string(img)
 
 
-@patch("src.autoscrapper.ocr.tesseract._get_api")
-@patch("src.autoscrapper.ocr.tesseract._get_api_line")
+@patch("autoscrapper.ocr.tesseract._get_api")
+@patch("autoscrapper.ocr.tesseract._get_api_line")
 def test_image_to_data_exception(mock_get_api_line, mock_get_api):
     mock_api = MagicMock()
     mock_api.GetIterator.side_effect = Exception("OCR failed")
@@ -430,7 +430,7 @@ def test_build_data_dict_all_levels():
     mock_word.Confidence.return_value = 95.5
     mock_word.GetUTF8Text.return_value = "TestWord"
 
-    with patch("src.autoscrapper.ocr.tesseract.iterate_level", return_value=[mock_word, mock_word]):
+    with patch("autoscrapper.ocr.tesseract.iterate_level", return_value=[mock_word, mock_word]):
         data = tesseract._build_data_dict(MagicMock())
 
         assert len(data["text"]) == 2
@@ -448,9 +448,9 @@ def test_build_data_dict_all_levels():
 
 def test_initialize_ocr_without_metadata():
     with (
-        patch("src.autoscrapper.ocr.tesseract._get_api"),
-        patch("src.autoscrapper.ocr.tesseract._get_api_line"),
-        patch("src.autoscrapper.ocr.tesseract._record_backend_info"),
+        patch("autoscrapper.ocr.tesseract._get_api"),
+        patch("autoscrapper.ocr.tesseract._get_api_line"),
+        patch("autoscrapper.ocr.tesseract._record_backend_info"),
     ):
         # Ensure _backend_info remains None
         tesseract._backend_info = None


### PR DESCRIPTION
Consolidates all open PRs into a single clean commit with all reviewer suggestions applied.

## Changes

### `src/autoscrapper/progress/data_update.py` (PR #124 + review suggestions)
- Replace sequential pagination loop with `concurrent.futures.ThreadPoolExecutor`
- Cap workers at `min(10, total_pages - 1)` (reviewer suggestion)
- Add `totalPages` validation with type coercion and clear error messages
- Include sequential `hasNextPage` fallback when `totalPages` is unavailable
- Add page number and URL to error messages for easier debugging

### `tests/autoscrapper/ocr/test_tesseract.py` (PR #124)
- Fix all patch paths from `src.autoscrapper.*` → `autoscrapper.*`

### `src/autoscrapper/ocr/inventory_vision.py` (PR #107)
- Remove misleading `# pragma: no cover - filesystem dependent` from `enable_ocr_debug` (now covered by test)
- Add accurate `# pragma: no cover - OCR-backend dependent` / `OCR backend dependent` / `OCR backend failure path` to OCR exception handlers

### `tests/autoscrapper/ocr/test_inventory_vision.py` (PR #107 + review suggestion)
- Add `test_enable_ocr_debug_success` to `TestEnableOcrDebug`

### `tests/autoscrapper/core/test_item_actions.py` (PR #136 + review suggestion)
- Add `test_load_item_actions_file_not_found` using real `tmp_path / "missing.json"` (reviewer-suggested approach, no mocking)
- Add `load_item_actions` to imports

### Formatting
- `ruff format` pass on `ui_windows.py`, `actions.py`, `test_rules_store.py`

## Already in main (no action needed)
- PR #90: Supabase key security fix + tests
- PR #108 / #110: `defaultdict` optimization in `inventory_vision.py`
- PR #117: `config.py` syntax fixes + `_load_config_dict` tests
- PR #120: `orjson.JSONDecodeError` fix + `rich_support.py` `Table as Table`

## Ghost branches deleted
`jules-8398143954020378437-1f770445`, `perf/optimize-setdefault-loop-10636450817590841950`, `session/agent_fd9418aa-*`, `session/agent_fe4bcd9d-*`