### PR TITLE
fix: restore context-menu detection for dark game UI

### DIFF
--- a/src/autoscrapper/ocr/inventory_vision.py
+++ b/src/autoscrapper/ocr/inventory_vision.py
@@ -595,16 +595,18 @@ def find_context_menu_crop(
     min_dim = int(round(100 * min(img_w, img_h) / 1080))
     if w < min_dim or h < min_dim:
         return None
-    # Brightness guard: verify the left half of the crop contains the
-    # bright cream/white background of the context menu panel.  The context
-    # menu has a mean grayscale brightness well above 120 (typically >200),
-    # while dark UI areas (LOADOUT slots, stash background) are well below
-    # 80.  Sampling only the left half avoids the dark inventory grid that
-    # can appear on the right side of the crop.
+    # Brightness guard: verify the left half of the crop contains UI
+    # content rather than empty stash background.  The context menu
+    # (whether the old light-cream style or the current dark UI) has
+    # text and panel elements that raise mean brightness above ~40,
+    # while the empty stash/inventory background sits below ~30.
+    # The previous threshold of 120 was calibrated for the old light
+    # cream menu and incorrectly rejected the game's current dark
+    # context menu (mean brightness ~60-100).
     crop_left_half = bgr_image[y : y2, x : x + max(1, w // 2)]
     if crop_left_half.size > 0:
         mean_brightness = float(np.mean(cv2.cvtColor(crop_left_half, cv2.COLOR_BGR2GRAY)))
-        if mean_brightness < 120.0:
+        if mean_brightness < 40.0:
             return None
     return x, y, w, h
 

--- a/src/autoscrapper/scanner/scan_loop.py
+++ b/src/autoscrapper/scanner/scan_loop.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass, field
 from itertools import cycle
-from typing import Any, Iterable, List, Optional, Tuple
+from typing import Any, Iterable, Iterator, List, Optional, Tuple
 
 from .actions import ActionExecutionContext, resolve_action_taken
 from .outcomes import _describe_action
@@ -116,7 +116,7 @@ def _queue_event(
         startup_events.append((message, style))
 
 
-def _scroll_clicks_sequence(click_pattern: Iterable[int]) -> Iterable[int]:
+def _scroll_clicks_sequence(click_pattern: Iterable[int]) -> Iterator[int]:
     """
     Yield repeating calibrated scroll counts.
     """
@@ -339,13 +339,15 @@ class _ScanRunner:
                 )
 
         # --- Attempt 2: color-based infobox detection with retries ---
-        # Also run when context-menu mode is active but the crop returned
-        # nothing (brightness guard rejected it — the menu was not visible).
-        # Falling back to infobox detection in that case prevents a permanent
-        # UNREADABLE for items where the context menu is absent but the
-        # hover-infobox is still showing.
-        ctx_menu_missed = skip_infobox and infobox_rect is None
-        if not skip_infobox or ctx_menu_missed:
+        # Only run when infobox mode is active or no mode has been
+        # established yet.  When context-menu mode is established
+        # (skip_infobox=True) but the crop returned nothing, the menu
+        # simply was not visible for this cell (e.g. empty slot or
+        # timing issue).  Falling through to infobox color detection
+        # adds multiple capture+sleep cycles with zero benefit because
+        # the game's current dark UI never matches the legacy
+        # INFOBOX_COLOR_BGR cream color.
+        if not skip_infobox:
             for attempt in range(1, self.config.infobox_retries + 1):
                 capture_attempts += 1
                 abort_if_escape_pressed(self.context.stop_key)


### PR DESCRIPTION
## Summary

- **Root cause**: Game's context menu changed from light-cream to dark UI. The brightness guard threshold (`120.0`) was calibrated for the old cream menu (mean brightness ~200) and silently rejected every valid dark context menu (mean brightness ~60–100), causing all items to parse as UNREADABLE.
- **Fix 1** (`inventory_vision.py`): Lower brightness guard from `120.0` → `40.0` — accepts the dark menu while still blocking empty stash background (~30).
- **Fix 2** (`scan_loop.py`): Skip dead infobox color-detection retries when `context_menu` mode is established — the legacy `INFOBOX_COLOR_BGR` cream color never appears in the current game UI, so these retries only add latency.
- **Fix 3** (`scan_loop.py`): Correct `_scroll_clicks_sequence` return type annotation `Iterable[int]` → `Iterator[int]`.

## Test plan

- [ ] Run `uv run autoscrapper scan --dry-run` against a live Arc Raiders inventory — items should now be read via context menu instead of UNREADABLE
- [ ] Check `ocr_debug/` — `ctx_menu_processed` files appear with item names; `infobox_detect_*` retry storm is gone
- [ ] `uv run ruff check src/ tests/` — no new errors
- [ ] `uv run pytest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)