### PR TITLE
🔒 [security fix] Fix Python 3 syntax errors in exception handling

### DIFF
--- a/.github/skills/lint-and-validate/scripts/lint_runner.py
+++ b/.github/skills/lint-and-validate/scripts/lint_runner.py
@@ -51,7 +51,7 @@ def detect_node_project(project_path: Path, result: dict[str, Any]) -> None:
             if "typescript" in deps or (project_path / "tsconfig.json").exists():
                 result["linters"].append({"name": "tsc", "cmd": ["npx", "tsc", "--noEmit"]})
 
-        except IOError, orjson.JSONDecodeError:
+        except (IOError, orjson.JSONDecodeError):
             pass
 
 

--- a/scripts/update_snapshot_and_defaults.py
+++ b/scripts/update_snapshot_and_defaults.py
@@ -124,7 +124,7 @@ def _is_ignorable_timestamp_only_json_diff(before: bytes, after: bytes) -> bool:
     try:
         before_json = orjson.loads(before)
         after_json = orjson.loads(after)
-    except orjson.JSONDecodeError, UnicodeDecodeError:
+    except (orjson.JSONDecodeError, UnicodeDecodeError):
         return False
 
     return _normalize_for_semantic_diff(before_json) == _normalize_for_semantic_diff(after_json)
@@ -244,7 +244,7 @@ def _git_sha() -> str:
             text=True,
             check=True,
         )
-    except subprocess.CalledProcessError, FileNotFoundError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return "unknown"
     return completed.stdout.strip() or "unknown"
 

--- a/src/autoscrapper/config.py
+++ b/src/autoscrapper/config.py
@@ -189,7 +189,7 @@ def _load_config_dict() -> ConfigDict:
         raw = orjson.loads(path.read_bytes())
     except FileNotFoundError:
         return {}
-    except OSError, orjson.JSONDecodeError:
+    except (OSError, orjson.JSONDecodeError):
         return {}
 
     if not isinstance(raw, dict):
@@ -329,7 +329,7 @@ def _from_raw_progress_settings(raw: Any) -> ProgressSettings:
         for key, value in hideout_levels_raw.items():
             try:
                 level = int(value)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 continue
             hideout_levels[str(key)] = level
 

--- a/src/autoscrapper/progress/data_update.py
+++ b/src/autoscrapper/progress/data_update.py
@@ -215,7 +215,7 @@ def _normalize_component_values(value: object) -> dict[str, int] | None:
             continue
         try:
             quantity = int(raw_quantity)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             continue
         if quantity <= 0:
             continue

--- a/src/autoscrapper/progress/decision_engine.py
+++ b/src/autoscrapper/progress/decision_engine.py
@@ -398,7 +398,7 @@ class DecisionEngine:
                 materials.append(f"{quantity}x {output_item.get('name')}")
                 try:
                     total_value += int(output_item.get("value", 0)) * int(quantity)
-                except TypeError, ValueError:
+                except (TypeError, ValueError):
                     continue
 
         return RecycleValue(

--- a/src/autoscrapper/progress/progress_config.py
+++ b/src/autoscrapper/progress/progress_config.py
@@ -50,7 +50,7 @@ def normalize_hideout_levels(input_levels: dict[str, int] | None, hideout_module
 
         try:
             level_num = int(raw_level)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             raise ValueError(f"Invalid hideout level for '{raw_key}': {raw_level}") from None
         if level_num < 0:
             raise ValueError(f"Invalid hideout level for '{raw_key}': {raw_level}")

--- a/src/autoscrapper/progress/update_report.py
+++ b/src/autoscrapper/progress/update_report.py
@@ -24,7 +24,7 @@ def _normalize_text(value: object) -> str:
 def _safe_float(value: object) -> float:
     try:
         return float(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return 0.0
 
 

--- a/tests/autoscrapper/ocr/test_ocr_fixtures.py
+++ b/tests/autoscrapper/ocr/test_ocr_fixtures.py
@@ -27,7 +27,7 @@ def _collect_fixtures() -> list[tuple[Path, str]]:
     for sidecar in sorted(FIXTURES_DIR.glob("*.json")):
         try:
             data = json.loads(sidecar.read_text(encoding="utf-8"))
-        except json.JSONDecodeError, OSError:
+        except (json.JSONDecodeError, OSError):
             continue
         expected_name = data.get("expected_name")
         if not isinstance(expected_name, str) or not expected_name:


### PR DESCRIPTION
🎯 **What:** This fix resolves a Python 3 `SyntaxError` across multiple files in the repository. The error was caused by using Python 2-style comma separation for multiple exceptions in `except` blocks (e.g., `except Exception1, Exception2:`), which is invalid in Python 3.

⚠️ **Risk:** If left unfixed, these scripts and modules cannot be compiled or executed in Python 3 environments. This impacts core functionality such as configuration loading, data updates, report generation, and automated linting/validation scripts.

🛡️ **Solution:** The fix standardizes all `except` blocks that catch multiple exceptions to use the Python 3-compliant tuple syntax (e.g., `except (Exception1, Exception2):`). This ensures broad compatibility with modern Python environments and restores the intended functionality of the affected modules.

---
*PR created automatically by Jules for task [692380193974504360](https://jules.google.com/task/692380193974504360) started by @Ven0m0*