### PR TITLE
🔒 Fix SyntaxError in progress config exception handling

### DIFF
--- a/src/autoscrapper/progress/progress_config.py
+++ b/src/autoscrapper/progress/progress_config.py
@@ -50,7 +50,7 @@ def normalize_hideout_levels(input_levels: dict[str, int] | None, hideout_module
 
         try:
             level_num = int(raw_level)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             raise ValueError(f"Invalid hideout level for '{raw_key}': {raw_level}") from None
         if level_num < 0:
             raise ValueError(f"Invalid hideout level for '{raw_key}': {raw_level}")

--- a/src/autoscrapper/scanner/scan_loop.py
+++ b/src/autoscrapper/scanner/scan_loop.py
@@ -193,6 +193,7 @@ def _detect_consecutive_empty_stop_idx(
         x, y, w, h = cell.safe_rect
         slot_bgr = window_bgr[y : y + h, x : x + w]
         if slot_bgr.size == 0:
+            prev_empty = False
             continue
         is_empty = is_slot_empty(slot_bgr)
         if is_empty and prev_empty:


### PR DESCRIPTION
🎯 **What:** Fixed a Python 3 SyntaxError in `src/autoscrapper/progress/progress_config.py` caused by legacy Python 2 exception syntax (`except TypeError, ValueError:`).

⚠️ **Risk:** A clear SyntaxError prevents module compilation and execution, causing the progress logic to fail to initialize and potentially stopping the application.

🛡️ **Solution:** Wrapped the exception types in parentheses (`except (TypeError, ValueError):`) to correctly catch multiple exceptions in Python 3. 
Also included a minor bug fix in `scan_loop.py` (`prev_empty = False` before `continue`) which resolved a failing test in the suite.

---
*PR created automatically by Jules for task [13690881636513553688](https://jules.google.com/task/13690881636513553688) started by @Ven0m0*