### PR TITLE
🧪 Add missing tests for `__main__.py`

### DIFF
--- a/tests/autoscrapper/test_main.py
+++ b/tests/autoscrapper/test_main.py
@@ -35,9 +35,9 @@ def test_main_help(capsys, arg) -> None:
 
 def test_main_scan() -> None:
     with patch("autoscrapper.scanner.cli.main") as mock_scan_main:
-        mock_scan_main.return_value = 0
+        mock_scan_main.return_value = 1
         result = main(["scan", "--dry-run"])
-        assert result == 0
+        assert result == 1
         mock_scan_main.assert_called_once_with(["--dry-run"])
 
 

--- a/tests/autoscrapper/test_main.py
+++ b/tests/autoscrapper/test_main.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+from autoscrapper.__main__ import _print_usage, main
+
+
+def test_main_no_args() -> None:
+    with patch("autoscrapper.__main__._run_tui") as mock_run_tui:
+        mock_run_tui.return_value = 0
+        result = main([])
+        assert result == 0
+        mock_run_tui.assert_called_once()
+
+
+def test_main_sys_argv_no_args() -> None:
+    with patch.object(sys, "argv", ["autoscrapper"]):
+        with patch("autoscrapper.__main__._run_tui") as mock_run_tui:
+            mock_run_tui.return_value = 0
+            result = main()
+            assert result == 0
+            mock_run_tui.assert_called_once()
+
+
+def test_main_help(capsys) -> None:
+    for arg in ["-h", "--help", "help"]:
+        result = main([arg])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Usage: autoscrapper" in captured.out
+
+
+def test_main_scan() -> None:
+    with patch("autoscrapper.scanner.cli.main") as mock_scan_main:
+        mock_scan_main.return_value = 0
+        result = main(["scan", "--dry-run"])
+        assert result == 0
+        mock_scan_main.assert_called_once_with(["--dry-run"])
+
+
+def test_main_unknown_command(capsys) -> None:
+    result = main(["unknown"])
+    assert result == 2
+    captured = capsys.readouterr()
+    assert "Unknown command: unknown" in captured.out
+    assert "Usage: autoscrapper" in captured.out
+
+
+def test_print_usage(capsys) -> None:
+    _print_usage()
+    captured = capsys.readouterr()
+    assert "Usage: autoscrapper" in captured.out

--- a/tests/autoscrapper/test_main.py
+++ b/tests/autoscrapper/test_main.py
@@ -10,9 +10,9 @@ from autoscrapper.__main__ import _print_usage, main
 
 def test_main_no_args() -> None:
     with patch("autoscrapper.__main__._run_tui") as mock_run_tui:
-        mock_run_tui.return_value = 0
+        mock_run_tui.return_value = 1
         result = main([])
-        assert result == 0
+        assert result == 1
         mock_run_tui.assert_called_once()
 
 

--- a/tests/autoscrapper/test_main.py
+++ b/tests/autoscrapper/test_main.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 from unittest.mock import patch
 
+import pytest
+
 from autoscrapper.__main__ import _print_usage, main
 
 

--- a/tests/autoscrapper/test_main.py
+++ b/tests/autoscrapper/test_main.py
@@ -25,12 +25,12 @@ def test_main_sys_argv_no_args() -> None:
             mock_run_tui.assert_called_once()
 
 
-def test_main_help(capsys) -> None:
-    for arg in ["-h", "--help", "help"]:
-        result = main([arg])
-        assert result == 0
-        captured = capsys.readouterr()
-        assert "Usage: autoscrapper" in captured.out
+@pytest.mark.parametrize("arg", ["-h", "--help", "help"])
+def test_main_help(capsys, arg) -> None:
+    result = main([arg])
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "Usage: autoscrapper" in captured.out
 
 
 def test_main_scan() -> None:


### PR DESCRIPTION
🎯 **What:** Added tests to cover the entrypoint for `autoscrapper/__main__.py`.

📊 **Coverage:** The test suite covers:
* `main()` executed with no arguments (falling back to Textual UI app `_run_tui()`).
* Help functionality flag handling (`-h`, `--help`, `help`).
* Valid subcommands like `scan` with arguments (`--dry-run`).
* Invalid or unknown subcommands leading to system exit 2 with help message output.

✨ **Result:** Improved test coverage across argument handling and initialization in `__main__.py`.

---
*PR created automatically by Jules for task [317162823414823698](https://jules.google.com/task/317162823414823698) started by @Ven0m0*