### PR TITLE
🧪 Add tests for untested isolate_menu_panel edge cases

### DIFF
--- a/tests/autoscrapper/ocr/test_inventory_vision.py
+++ b/tests/autoscrapper/ocr/test_inventory_vision.py
@@ -676,6 +676,24 @@ class TestIsolateMenuPanel:
         assert x + w <= crop_w
         assert y + h <= crop_h
 
+    def test_returns_none_for_thin_horizontal_strip(self):
+        """A bright rect that is too wide/short (aspect < 0.3) must not be returned."""
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        img[40:50, 10:90] = (220, 220, 220)
+        assert isolate_menu_panel(img) is None
+
+    def test_returns_none_for_thin_vertical_strip(self):
+        """A bright rect that is too tall/narrow (aspect > 3.0) must not be returned."""
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        img[10:90, 45:55] = (220, 220, 220)
+        assert isolate_menu_panel(img) is None
+
+    def test_returns_none_for_short_panel(self):
+        """A bright rect covering < 50% of crop height must not be returned."""
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        img[20:60, 20:60] = (220, 220, 220)
+        assert isolate_menu_panel(img) is None
+
 
 # ---------------------------------------------------------------------------
 # match_item_name_result — case-insensitivity regression

--- a/tests/autoscrapper/ocr/test_inventory_vision.py
+++ b/tests/autoscrapper/ocr/test_inventory_vision.py
@@ -677,9 +677,9 @@ class TestIsolateMenuPanel:
         assert y + h <= crop_h
 
     def test_returns_none_for_thin_horizontal_strip(self):
-        """A bright rect that is too wide/short (aspect < 0.3) must not be returned."""
-        img = np.zeros((100, 100, 3), dtype=np.uint8)
-        img[40:50, 10:90] = (220, 220, 220)
+        """A bright rect that is too wide/short (aspect > 3.0) must not be returned."""
+        img = np.zeros((100, 400, 3), dtype=np.uint8)
+        img[20:80, 50:350] = (220, 220, 220)  # bw=300, bh=60, area=18000, aspect=5.0
         assert isolate_menu_panel(img) is None
 
     def test_returns_none_for_thin_vertical_strip(self):

--- a/tests/autoscrapper/ocr/test_inventory_vision.py
+++ b/tests/autoscrapper/ocr/test_inventory_vision.py
@@ -683,9 +683,9 @@ class TestIsolateMenuPanel:
         assert isolate_menu_panel(img) is None
 
     def test_returns_none_for_thin_vertical_strip(self):
-        """A bright rect that is too tall/narrow (aspect > 3.0) must not be returned."""
+        """A bright rect that is too tall/narrow (aspect < 0.3) must not be returned."""
         img = np.zeros((100, 100, 3), dtype=np.uint8)
-        img[10:90, 45:55] = (220, 220, 220)
+        img[10:90, 40:60] = (220, 220, 220)  # bw=20, bh=80, area=1600, aspect=0.25
         assert isolate_menu_panel(img) is None
 
     def test_returns_none_for_short_panel(self):


### PR DESCRIPTION
🎯 **What:** Addressed the testing gap in `isolate_menu_panel` where contour edge cases (thin/short panels) were returning `None` without being verified by tests.
📊 **Coverage:** Added explicit test scenarios for thin horizontal strips (aspect ratio < 0.3), thin vertical strips (aspect ratio > 3.0), and short panels (height < 50%).
✨ **Result:** The `isolate_menu_panel` function is now fully tested, preventing regressions to the aspect ratio and height validations.

---
*PR created automatically by Jules for task [1889246350033679616](https://jules.google.com/task/1889246350033679616) started by @Ven0m0*