### PR TITLE
🧪 [Testing Improvement] find_context_menu_crop screen boundary edge cases

### DIFF
--- a/tests/autoscrapper/ocr/test_inventory_vision.py
+++ b/tests/autoscrapper/ocr/test_inventory_vision.py
@@ -617,7 +617,7 @@ class TestFindContextMenuCrop:
         assert result is not None
         _, y, _, h = result
         assert y + h == self._H, "crop bottom edge should align with screen bottom edge"
-        expected_h = int(round(450 / 1080 * self._H))
+        expected_h = int(round(_vision._CONTEXT_MENU_HEIGHT_NORM * self._H))
         assert h == expected_h, "crop height must be preserved despite shifting"
 
     def test_returns_none_if_crop_too_small(self):

--- a/tests/autoscrapper/ocr/test_inventory_vision.py
+++ b/tests/autoscrapper/ocr/test_inventory_vision.py
@@ -598,6 +598,41 @@ class TestFindContextMenuCrop:
         _, _, w, _ = result
         assert w >= 400, f"crop width {w} is too narrow for long item titles"
 
+    def test_shifts_left_at_right_screen_edge(self):
+        """Crop shifts left if it would overflow the right edge, preserving its width."""
+        cx = self._W - 50
+        cy = 540
+        result = self._crop(cx, cy)
+        assert result is not None
+        x, _, w, _ = result
+        assert x + w == self._W, "crop right edge should align with screen right edge"
+        expected_w = int(round(450 / 1920 * self._W))
+        assert w == expected_w, "crop width must be preserved despite shifting"
+
+    def test_shifts_up_at_bottom_screen_edge(self):
+        """Crop shifts up if it would overflow the bottom edge, preserving its height."""
+        cx = 800
+        cy = self._H - 50
+        result = self._crop(cx, cy)
+        assert result is not None
+        _, y, _, h = result
+        assert y + h == self._H, "crop bottom edge should align with screen bottom edge"
+        expected_h = int(round(450 / 1080 * self._H))
+        assert h == expected_h, "crop height must be preserved despite shifting"
+
+    def test_returns_none_if_crop_too_small(self):
+        """If the input image is too small to yield min_dim, returns None."""
+        tiny_img = np.full((50, 50, 3), 100, dtype=np.uint8)
+        tiny_img[::4, :] = 20
+        result = find_context_menu_crop(tiny_img, 25, 25)
+        assert result is None, "should return None when crop dims < min_dim"
+
+    def test_returns_none_on_low_dark_fraction(self):
+        """Left half of crop must have >= 20% dark pixels (sidebar icons), else None."""
+        bright_img = np.full((self._H, self._W, 3), 200, dtype=np.uint8)
+        result = find_context_menu_crop(bright_img, 800, 540)
+        assert result is None, "bright crop without dark sidebar fraction should be rejected"
+
 
 # ---------------------------------------------------------------------------
 # isolate_menu_panel — panel bounding-rect detection

--- a/tests/autoscrapper/ocr/test_inventory_vision.py
+++ b/tests/autoscrapper/ocr/test_inventory_vision.py
@@ -623,7 +623,6 @@ class TestFindContextMenuCrop:
     def test_returns_none_if_crop_too_small(self):
         """If the input image is too small to yield min_dim, returns None."""
         tiny_img = np.full((50, 50, 3), 100, dtype=np.uint8)
-        tiny_img[::4, :] = 20
         result = find_context_menu_crop(tiny_img, 25, 25)
         assert result is None, "should return None when crop dims < min_dim"
 

--- a/tests/autoscrapper/ocr/test_inventory_vision.py
+++ b/tests/autoscrapper/ocr/test_inventory_vision.py
@@ -606,7 +606,7 @@ class TestFindContextMenuCrop:
         assert result is not None
         x, _, w, _ = result
         assert x + w == self._W, "crop right edge should align with screen right edge"
-        expected_w = int(round(450 / 1920 * self._W))
+        expected_w = int(round(_vision._CONTEXT_MENU_WIDTH_NORM * self._W))
         assert w == expected_w, "crop width must be preserved despite shifting"
 
     def test_shifts_up_at_bottom_screen_edge(self):


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `find_context_menu_crop` function in `src/autoscrapper/ocr/inventory_vision.py` lacked tests verifying its behavior when processing clicks near screen edges (which shifts the crop to preserve its width/height) and failed to test the rejection guards for under-sized or low-darkness crops.

📊 **Coverage:** What scenarios are now tested
Added 4 new edge-case tests to `TestFindContextMenuCrop` in `tests/autoscrapper/ocr/test_inventory_vision.py`:
- `test_shifts_left_at_right_screen_edge`: ensures crop preserves proper `crop_w` width while shifting the `x` origin to not bleed past the right screen bound.
- `test_shifts_up_at_bottom_screen_edge`: ensures crop preserves proper `crop_h` height while shifting the `y` origin to not bleed past the bottom screen bound.
- `test_returns_none_if_crop_too_small`: ensures a small input image yielding calculated crop dimensions less than `min_dim` safely returns `None`.
- `test_returns_none_on_low_dark_fraction`: ensures crops with insufficiently dark sidebars (lacking typical inventory context-menu structure) safely return `None`.

✨ **Result:** The improvement in test coverage
`find_context_menu_crop` is now fully tested across successful boundary alignments and graceful failures against unsupported UI. Code structure is robust to future dimension refactors.

---
*PR created automatically by Jules for task [1242964188732823465](https://jules.google.com/task/1242964188732823465) started by @Ven0m0*