### PR TITLE
fix(renovate): replace invalid Python version range with valid semver range

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,7 @@
   "prHourlyLimit": 0,
   "rangeStrategy": "bump",
   "constraints": {
-    "python": ">=3.13, !=3.14.*"
+    "python": ">=3.13 <3.14"
   },
   "pep621": {
     "enabled": true
@@ -57,14 +57,14 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["python"],
       "pinDigests": false,
-      "allowedVersions": ">=3.13, !=3.14.*"
+      "allowedVersions": ">=3.13 <3.14"
     },
     {
       "description": "Allow any Python version >=3.13 but exclude 3.14.x series",
       "matchManagers": ["pep621"],
       "matchPackageNames": ["python"],
       "matchDepTypes": ["requires-python"],
-      "allowedVersions": ">=3.13, !=3.14.*"
+      "allowedVersions": ">=3.13 <3.14"
     },
     {
       "description": "Disable Docker digest pinning",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces `">=3.13, !=3.14.*"` (invalid Renovate syntax) with `">=3.13 <3.14"` in all three locations: `constraints.python` and both `allowedVersions` package rules (Docker and pep621)
- The new range allows any 3.13.x patch version, blocks upgrades to 3.14+, and does not pin to a specific patch like 3.13.13
- Fixes the Renovate config error that was blocking all PRs (#252)

## Test plan

- [ ] Verify Renovate closes issue #252 after this merges and re-validates the config

Fixes #252

https://claude.ai/code/session_01P6KUqpRTYz7ZWqdNHpymBC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6KUqpRTYz7ZWqdNHpymBC)_