### PR TITLE
fix(renovate): restrict mise python updates to <3.14

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,9 +48,7 @@
     "enabled": false
   },
   "npm": {
-    "managerFilePatterns": [
-      "/.kilo/package.json/"
-    ]
+    "managerFilePatterns": ["/.kilo/package.json/"]
   },
   "postUpdateOptions": ["uvLockUpdate"],
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -69,6 +69,12 @@
       "allowedVersions": ">=3.13 <3.14"
     },
     {
+      "description": "Restrict mise Python to 3.13.x, exclude 3.14+",
+      "matchManagers": ["mise"],
+      "matchPackageNames": ["python"],
+      "allowedVersions": ">=3.13 <3.14"
+    },
+    {
       "description": "Disable Docker digest pinning",
       "matchDatasources": ["docker"],
       "pinDigests": false


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a `packageRule` for the `mise` manager to restrict Python updates to `>=3.13 <3.14`
- Renovate was proposing `python 3.13.13 → 3.14.4` for `mise.toml` because no rule covered the mise manager
- Rules already existed for `pep621` and `docker` managers — this fills the gap

## Test plan

- [ ] Verify Renovate no longer proposes a 3.14.x update for `mise.toml` after next run
- [ ] Confirm `renovate.json` is valid JSON (checked locally)

Closes #22 (the mise python 3.14.4 update in the Dependency Dashboard)

https://claude.ai/code/session_014skBSXKeBzntbrdFs2bq2t
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014skBSXKeBzntbrdFs2bq2t)_