### PR TITLE
chore(renovate): cap Python at <3.14 for pyenv and remove redundant presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,13 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-    "config:recommended",
     ":configMigration",
     "abandonments:recommended",
     "group:all",
     "packages:linters",
     "schedule:weekly",
-    ":dependencyDashboard",
     ":automergeMinor",
     ":ignoreModulesAndTests",
     "docker:enableMajor",
@@ -75,6 +73,12 @@
       "allowedVersions": "<3.14"
     },
     {
+      "description": "Restrict .python-version (pyenv) to exclude 3.14+",
+      "matchManagers": ["pyenv"],
+      "matchPackageNames": ["python"],
+      "allowedVersions": "<3.14"
+    },
+    {
       "description": "Disable Docker digest pinning",
       "matchDatasources": ["docker"],
       "pinDigests": false
@@ -126,7 +130,6 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["**/.github/workflows/*.yml", "**/.github/workflows/*.yaml"],
-      "datasourceTemplate": "github-releases",
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)(?: version=[^\\s]+)?\\s+[A-Za-z0-9_]+_VERSION:\\s*['\"]?(?<currentValue>[^'\"\\s]+)['\"]?"
       ]

--- a/renovate.json
+++ b/renovate.json
@@ -73,8 +73,8 @@
       "allowedVersions": "<3.14"
     },
     {
-      "description": "Restrict .python-version (pyenv) to exclude 3.14+",
-      "matchManagers": ["pyenv"],
+      "description": "Restrict Python version to exclude 3.14+ for pyenv, pep723 and custom managers",
+      "matchManagers": ["pyenv", "pep723", "regex"],
       "matchPackageNames": ["python"],
       "allowedVersions": "<3.14"
     },


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Add `pyenv` packageRule** with `allowedVersions: "<3.14"` to cover `.python-version` — this was the missing guard; all other managers (pep621, mise, docker) already had the cap but pyenv did not
- **Remove `config:recommended`** from `extends` — `config:best-practices` already extends it, so it was a no-op duplicate
- **Remove `:dependencyDashboard`** from `extends` — also already included by `config:best-practices`
- **Remove `datasourceTemplate: "github-releases"`** from the custom regex manager — the regex already captures `(?<datasource>...)` from the inline comment; the hardcoded template silently overrode that capture group, breaking any non-github-releases datasource annotations in workflow files

## Test plan

- [ ] Verify Renovate dry-run does not propose a `.python-version` bump to 3.14+
- [ ] Verify Renovate dry-run does not propose a `requires-python` bump past `<3.14` in `pyproject.toml`
- [ ] Confirm dependency dashboard still appears (provided by `config:best-practices`)

https://claude.ai/code/session_01HXVyJe55dRMyAhDZ52nkHD
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXVyJe55dRMyAhDZ52nkHD)_