### PR TITLE
ci: replace direct apt-get with gerlero/apt-install + fast mirror

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Configure fast apt mirror
-        uses: mirror-mirrors/configure-fast-apt-mirror@v1
+        uses: vegardit/fast-apt-mirror.sh@v1
       - name: Install Linux system dependencies
         uses: gerlero/apt-install@v1
         with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -12,23 +12,18 @@ permissions:
 concurrency:
   group: copilot-setup-${{ github.ref }}
   cancel-in-progress: true
-env:
-  DEBIAN_FRONTEND: noninteractive
-  DEBCONF_NOWARNINGS: yes
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Configure fast apt mirror
+        uses: mirror-mirrors/configure-fast-apt-mirror@v1
       - name: Install Linux system dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -yqq --no-install-recommends \
-            build-essential \
-            libleptonica-dev \
-            libtesseract-dev \
-            pkg-config \
-            tesseract-ocr
+        uses: gerlero/apt-install@v1
+        with:
+          packages: build-essential libleptonica-dev libtesseract-dev pkg-config tesseract-ocr
+          install-recommends: false
       - name: Install uv and Python 3.13
         uses: astral-sh/setup-uv@v8.1.0
         with:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -19,9 +19,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Configure fast apt mirror
+        uses: mirror-mirrors/configure-fast-apt-mirror@v1
       - name: Install Tesseract OCR system dependencies
-        run: |
-          sudo apt-get update -qq >/dev/null 2>&1 && sudo apt-get install -yqq --no-install-recommends build-essential libevdev-dev libleptonica-dev libtesseract-dev pkg-config tesseract-ocr libwebp7
+        uses: gerlero/apt-install@v1
+        with:
+          packages: build-essential libevdev-dev libleptonica-dev libtesseract-dev pkg-config tesseract-ocr libwebp7
+          install-recommends: false
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Configure fast apt mirror
-        uses: mirror-mirrors/configure-fast-apt-mirror@v1
+        uses: vegardit/fast-apt-mirror.sh@v1
       - name: Install Tesseract OCR system dependencies
         uses: gerlero/apt-install@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,12 +24,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Configure fast apt mirror
+        uses: mirror-mirrors/configure-fast-apt-mirror@v1
       - name: Install system dependencies
-        run: |
-          sudo apt-get update -qq >/dev/null 2>&1
-          sudo apt-get install -yqq --no-install-recommends \
-            build-essential libevdev-dev libleptonica-dev libtesseract-dev \
-            pkg-config tesseract-ocr libwebp7 libgl1
+        uses: gerlero/apt-install@v1
+        with:
+          packages: build-essential libevdev-dev libleptonica-dev libtesseract-dev pkg-config tesseract-ocr libwebp7 libgl1
+          install-recommends: false
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Configure fast apt mirror
-        uses: mirror-mirrors/configure-fast-apt-mirror@v1
+        uses: vegardit/fast-apt-mirror.sh@v1
       - name: Install system dependencies
         uses: gerlero/apt-install@v1
         with:


### PR DESCRIPTION
## Summary

- Replace all inline `sudo apt-get update/install` calls in CI workflows with `gerlero/apt-install@v1` (`install-recommends: false`)
- Add `mirror-mirrors/configure-fast-apt-mirror@v1` before each install step for faster package downloads
- Drop now-redundant `DEBIAN_FRONTEND`/`DEBCONF_NOWARNINGS` env vars from `copilot-setup-steps.yml` (the action handles this internally)

Affected workflows: `copilot-setup-steps.yml`, `tests.yml`, `ruff.yml`

## Test plan

- [ ] Verify `copilot-setup-steps.yml` run succeeds end-to-end
- [ ] Verify `tests.yml` (pytest matrix) passes
- [ ] Verify `ruff.yml` (CI) passes with lint + type + test steps intact

https://claude.ai/code/session_01FWHCDneMuS1ojK5WkgGvjC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWHCDneMuS1ojK5WkgGvjC)_