### PR TITLE
fix(skills): normalize Windows path separators in config-bump skill

### DIFF
--- a/.claude/skills/config-bump/SKILL.md
+++ b/.claude/skills/config-bump/SKILL.md
@@ -56,7 +56,7 @@ uv run pytest tests/autoscrapper/test_config.py -v
 The test suite covers round-trip serialization, version migration, and field clamping. All tests must pass.
 
 ### 5. Verify loading from old config
-If you have a real config file at `%APPDATA%\autoscrapper\config.json` (Windows), confirm it loads without errors after the bump:
+If you have a real config file at `%APPDATA%/autoscrapper/config.json` (Windows), confirm it loads without errors after the bump:
 
 uv run autoscrapper scan --dry-run
 

--- a/.kilo/skills/config-bump/SKILL.md
+++ b/.kilo/skills/config-bump/SKILL.md
@@ -56,7 +56,7 @@ uv run pytest tests/autoscrapper/test_config.py -v
 The test suite covers round-trip serialization, version migration, and field clamping. All tests must pass.
 
 ### 5. Verify loading from old config
-If you have a real config file at `%APPDATA%\autoscrapper\config.json` (Windows), confirm it loads without errors after the bump:
+If you have a real config file at `%APPDATA%/autoscrapper/config.json` (Windows), confirm it loads without errors after the bump:
 
 uv run autoscrapper scan --dry-run
 


### PR DESCRIPTION
## Summary

- `agnix --fix-safe` applied a partial path-separator fix to `config-bump/SKILL.md` in both `.claude/skills/` and `.kilo/skills/`, converting only the second backslash and leaving a mixed-separator path (`%APPDATA%\autoscrapper/config.json`). This commit completes the normalization to all forward slashes (`%APPDATA%/autoscrapper/config.json`), which is valid on Windows via Python pathlib and consistent.

## Test plan

- [ ] Confirm `npx agnix --fix-safe .` reports "No fixes to apply" for these two files

https://claude.ai/code/session_0125jFsrA3psGXkR69KFwegK

---
_Generated by [Claude Code](https://claude.ai/code/session_0125jFsrA3psGXkR69KFwegK)_