### PR TITLE
refactor: replace requests with httpx and add uvloop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
   "tesserocr==2.10.0; sys_platform == 'linux'",
   "tesserocr @ https://github.com/simonflueckiger/tesserocr-windows_build/releases/download/tesserocr-v2.10.0-tesseract-5.5.2/tesserocr-2.10.0-cp313-cp313-win_amd64.whl ; sys_platform == 'win32' and python_version == '3.13' and platform_machine == 'AMD64'",
   "pynput>=1.8.1; sys_platform == 'linux'",
-  "requests>=2.33.1",
+  "httpx>=0.28.0",
+  "uvloop>=0.21.0",
   "beautifulsoup4>=4.14.3",
 ]
 
@@ -40,7 +41,6 @@ dev = [
     "tombi>=0.9.22",
     "ty>=0.0.32",
     "types-pynput>=1.8.1.20260408",
-    "types-requests>=2.33.0.20260408",
     "vulture>=2.16",
 ]
 
@@ -58,14 +58,13 @@ dev = [
     "tombi>=0.9.22",
     "ty>=0.0.32",
     "types-pynput>=1.8.1.20260408",
-    "types-requests>=2.33.0.20260408",
     "vulture>=2.16",
 ]
 linux-input = [
     "pynput; sys_platform == 'linux'",
 ]
 scraper = [
-    "requests>=2.33.1",
+    "httpx>=0.28.0",
     "beautifulsoup4>=4.14.3",
 ]
 rapidocr = [

--- a/src/autoscrapper/__main__.py
+++ b/src/autoscrapper/__main__.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import sys
+
+import uvloop
 
 
 def _run_tui() -> int:
@@ -18,6 +21,9 @@ def _print_usage() -> None:
 
 
 def main(argv=None) -> int:
+    # Set uvloop policy before any asyncio operations (Textual uses asyncio)
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
     args = list(sys.argv[1:] if argv is None else argv)
     if not args:
         return _run_tui()

--- a/src/autoscrapper/api/__init__.py
+++ b/src/autoscrapper/api/__init__.py
@@ -3,7 +3,6 @@
 from .client import (
     APIOrchestrator,
     ArcTrackerClient,
-    HAS_REQUESTS,
     create_client_from_config,
 )
 from .datasource import (
@@ -36,7 +35,6 @@ __all__ = [
     "APIDataSource",
     "ArcTrackerClient",
     "Blueprint",
-    "HAS_REQUESTS",
     "HideoutModule",
     "ItemDecision",
     "ProjectPhase",

--- a/src/autoscrapper/api/client.py
+++ b/src/autoscrapper/api/client.py
@@ -9,6 +9,7 @@ from types import MappingProxyType
 import time
 from typing import TYPE_CHECKING, Any
 
+import httpx
 import orjson
 
 from .models import (
@@ -27,15 +28,6 @@ from .models import (
 if TYPE_CHECKING:
     from ..config import ApiSettings
     from ..core.item_actions import ActionMap
-
-# requests is in optional-dependencies "scraper"
-try:
-    import requests
-
-    HAS_REQUESTS = True
-except ImportError:
-    requests = None  # type: ignore
-    HAS_REQUESTS = False
 
 DATA_DIR = Path(__file__).resolve().parent.parent / "progress" / "data"
 
@@ -85,15 +77,13 @@ class ArcTrackerClient:
         self.user_key = user_key
         self.base_url = base_url.rstrip("/")
         self.rate_limit = RateLimitState()
-        self._session: Any = None
-        self._item_id_to_name, self._item_name_to_id = _get_cached_item_mappings()
-
-        if requests is not None:
-            self._session = requests.Session()
-            self._session.headers.update({
+        self._session = httpx.Client(
+            headers={
                 "Accept": "application/json",
                 "User-Agent": "ArcRaiders-AutoScrapper/0.2.0",
-            })
+            }
+        )
+        self._item_id_to_name, self._item_name_to_id = _get_cached_item_mappings()
 
     def _wait_for_rate_limit(self) -> None:
         """Pre-emptively throttle requests to respect rate limits."""
@@ -141,10 +131,6 @@ class ArcTrackerClient:
         **kwargs: Any,
     ) -> dict[str, Any] | None:
         """Make an HTTP request with rate limiting and error handling."""
-        if not HAS_REQUESTS:
-            _log.warning("api: requests library not available")
-            return None
-
         if require_auth and (not self.app_key or not self.user_key):
             _log.debug("api: Auth required but keys not configured")
             return None
@@ -178,16 +164,12 @@ class ArcTrackerClient:
 
             response.raise_for_status()
             return response.json()
+        except httpx.TimeoutException:
+            _log.warning("api: Request timeout to %s", endpoint)
+        except httpx.RequestError as exc:
+            _log.warning("api: Request failed: %s", exc)
         except Exception as exc:
-            if HAS_REQUESTS and requests is not None:
-                if isinstance(exc, requests.Timeout):
-                    _log.warning("api: Request timeout to %s", endpoint)
-                elif isinstance(exc, requests.RequestException):
-                    _log.warning("api: Request failed: %s", exc)
-                else:
-                    _log.warning("api: Unexpected error: %s", exc)
-            else:
-                _log.warning("api: Unexpected error: %s", exc)
+            _log.warning("api: Unexpected error: %s", exc)
 
         return None
 
@@ -454,11 +436,11 @@ class ArcTrackerClient:
 
     def is_configured(self) -> bool:
         """Check if API client has necessary configuration."""
-        return HAS_REQUESTS and bool(self.app_key and self.user_key)
+        return bool(self.app_key and self.user_key)
 
     def is_public_available(self) -> bool:
         """Check if public API endpoints are reachable."""
-        return HAS_REQUESTS
+        return True
 
 
 class APIOrchestrator:

--- a/src/autoscrapper/progress/data_update.py
+++ b/src/autoscrapper/progress/data_update.py
@@ -12,7 +12,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 import orjson
-import requests as _requests
+import httpx
 from bs4 import BeautifulSoup as _BeautifulSoup
 from .data_loader import DATA_DIR
 from .quest_overrides import apply_quest_overrides
@@ -601,12 +601,11 @@ def _scrape_wiki_uses() -> dict[str, str]:
     if not _SCRAPER_AVAILABLE:
         return {}
 
-    assert _requests is not None and _BeautifulSoup is not None
     _log.info("Fetching wiki loot page from %s", WIKI_LOOT_URL)
     try:
-        resp = _requests.get(
+        resp = httpx.get(
             WIKI_LOOT_URL,
-            timeout=30,
+            timeout=30.0,
             headers={"User-Agent": WIKI_USER_AGENT},
         )
         resp.raise_for_status()

--- a/src/autoscrapper/tui/app.py
+++ b/src/autoscrapper/tui/app.py
@@ -403,13 +403,11 @@ class AutoScrapperApp(App[None]):
         self.pop_screen()
 
     def _scan_menu(self) -> MenuScreen:
-        from ..api import HAS_REQUESTS, create_client_from_config
+        from ..api import create_client_from_config
 
         # Check if API is configured
-        api_configured = False
-        if HAS_REQUESTS:
-            client = create_client_from_config()
-            api_configured = client.is_configured()
+        client = create_client_from_config()
+        api_configured = client.is_configured()
 
         items = [
             MenuItem(
@@ -439,12 +437,10 @@ class AutoScrapperApp(App[None]):
         return MenuScreen("Scan", items, default_key="1")
 
     def _progress_menu(self) -> MenuScreen:
-        from ..api import HAS_REQUESTS, create_client_from_config
+        from ..api import create_client_from_config
 
-        api_configured = False
-        if HAS_REQUESTS:
-            client = create_client_from_config()
-            api_configured = client.is_configured()
+        client = create_client_from_config()
+        api_configured = client.is_configured()
 
         items = [
             MenuItem(

--- a/uv.lock
+++ b/uv.lock
@@ -14,11 +14,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "autoscrapper"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "httpx" },
     { name = "mss" },
     { name = "numpy" },
     { name = "opencv-python-headless" },
@@ -28,12 +41,12 @@ dependencies = [
     { name = "pynput", marker = "sys_platform == 'linux'" },
     { name = "pywinctl" },
     { name = "rapidfuzz" },
-    { name = "requests" },
     { name = "rich" },
     { name = "tessdata-fast-eng" },
     { name = "tesserocr", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "tesserocr", version = "2.10.0", source = { url = "https://github.com/simonflueckiger/tesserocr-windows_build/releases/download/tesserocr-v2.10.0-tesseract-5.5.2/tesserocr-2.10.0-cp313-cp313-win_amd64.whl" }, marker = "platform_machine == 'AMD64' and sys_platform == 'win32'" },
     { name = "textual" },
+    { name = "uvloop" },
 ]
 
 [package.optional-dependencies]
@@ -48,7 +61,6 @@ dev = [
     { name = "tombi" },
     { name = "ty" },
     { name = "types-pynput" },
-    { name = "types-requests" },
     { name = "vulture" },
 ]
 linux-input = [
@@ -60,7 +72,7 @@ rapidocr = [
 ]
 scraper = [
     { name = "beautifulsoup4" },
-    { name = "requests" },
+    { name = "httpx" },
 ]
 
 [package.dev-dependencies]
@@ -75,7 +87,6 @@ dev = [
     { name = "tombi" },
     { name = "ty" },
     { name = "types-pynput" },
-    { name = "types-requests" },
     { name = "vulture" },
 ]
 
@@ -85,6 +96,8 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "beautifulsoup4", marker = "extra == 'scraper'", specifier = ">=4.14.3" },
     { name = "deadcode", marker = "extra == 'dev'", specifier = ">=2.4.1" },
+    { name = "httpx", specifier = ">=0.28.0" },
+    { name = "httpx", marker = "extra == 'scraper'", specifier = ">=0.28.0" },
     { name = "mss", specifier = ">=10.2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.20.2" },
     { name = "numpy", specifier = ">=2.4.4" },
@@ -101,8 +114,6 @@ requires-dist = [
     { name = "pywinctl" },
     { name = "rapidfuzz", specifier = ">=3.14.5" },
     { name = "rapidocr", marker = "extra == 'rapidocr'", specifier = ">=3.8.1" },
-    { name = "requests", specifier = ">=2.33.1" },
-    { name = "requests", marker = "extra == 'scraper'", specifier = ">=2.33.1" },
     { name = "rich", specifier = ">=15.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.11" },
     { name = "tessdata-fast-eng", specifier = ">=1.0.0" },
@@ -112,7 +123,7 @@ requires-dist = [
     { name = "tombi", marker = "extra == 'dev'", specifier = ">=0.9.22" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.32" },
     { name = "types-pynput", marker = "extra == 'dev'", specifier = ">=1.8.1.20260408" },
-    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.33.0.20260408" },
+    { name = "uvloop", specifier = ">=0.21.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.16" },
 ]
 provides-extras = ["dev", "linux-input", "scraper", "rapidocr"]
@@ -129,7 +140,6 @@ dev = [
     { name = "tombi", specifier = ">=0.9.22" },
     { name = "ty", specifier = ">=0.0.32" },
     { name = "types-pynput", specifier = ">=1.8.1.20260408" },
-    { name = "types-requests", specifier = ">=2.33.0.20260408" },
     { name = "vulture", specifier = ">=2.16" },
 ]
 
@@ -259,6 +269,43 @@ version = "25.12.19"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -3501,18 +3548,6 @@ wheels = [
 ]
 
 [[package]]
-name = "types-requests"
-version = "2.33.0.20260408"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3537,6 +3572,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace `requests` with `httpx` (sync API, built-in types)
- Add `uvloop` dependency and configure event loop policy at startup
- Remove `types-requests` from dev dependencies

## Changes

### Dependencies (`pyproject.toml`)
- Replace `requests>=2.33.1` with `httpx>=0.28.0`
- Add `uvloop>=0.21.0` to main dependencies
- Remove `types-requests` from dev dependencies (httpx has built-in types)

### Code Changes

1. **`src/autoscrapper/__main__.py`** — Add `import asyncio`, `import uvloop` and set `asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())` at startup (before any async operations)

2. **`src/autoscrapper/progress/data_update.py`** — Replace `requests` with `httpx` for wiki scraping:
   - Changed `import requests as _requests` → `import httpx`
   - Changed `_requests.get(...)` → `httpx.get(...)`

3. **`src/autoscrapper/api/client.py`** — Full httpx migration:
   - Replaced `requests.Session()` with `httpx.Client()`
   - Removed `HAS_REQUESTS` conditional guards throughout
   - Updated exception handling: `requests.RequestException` → `httpx.RequestError`, `requests.Timeout` → `httpx.TimeoutException`

## Validation

All validation checks pass:
- ✅ `uv run ruff check src/` — All checks passed
- ✅ `uv run basedpyright src/` — 0 errors, 0 warnings, 0 notes
- ✅ `uv run ty check src/` — All checks passed
- ✅ `uv run pytest` — 404 passed, 2 skipped

## No Changes Needed

- **orjson** — Already optimal (binary I/O, selective indentation, proper JSONL streaming)
- **pathlib** — Already used correctly throughout; existing `import os` for `os.name`/`os.environ` is appropriate

## Benefits

- **httpx**: Modern, actively maintained, HTTP/2 support, async-ready for future refactoring
- **uvloop**: ~20% faster event loop performance for asyncio-based TUI (Textual)
