### PR TITLE
fix(workflow): use setup-python before setup-uv for GitHub caching

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version-file: "pyproject.toml"
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: "Set up Python"
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
-      - name: Install Python 3.13
-        run: uv python install 3.13
+        with:
+          enable-cache: true
       - name: Build
         run: uv build
       - name: Publish


### PR DESCRIPTION
Optimize GitHub workflows by adding setup-python action before setup-uv to enable proper caching. Also fixes publish.yml to use pyproject.toml instead of hardcoded Python version.