### PR TITLE
🔒 Fix argument injection vulnerability in benchmark script

### DIFF
--- a/scripts/benchmark_tessdata_models.py
+++ b/scripts/benchmark_tessdata_models.py
@@ -92,17 +92,15 @@ def _run_worker(manifest_path: Path, label: str) -> dict[str, object]:
         is_correct = result.item_name == sample.expected_name
         if is_correct:
             correct_count += 1
-        sample_reports.append(
-            {
-                "sample_id": sample.sample_id,
-                "image_path": image_path.as_posix(),
-                "expected_name": sample.expected_name,
-                "recognized_name": result.item_name,
-                "raw_item_text": result.raw_item_text,
-                "correct": is_correct,
-                "elapsed_seconds": elapsed,
-            }
-        )
+        sample_reports.append({
+            "sample_id": sample.sample_id,
+            "image_path": image_path.as_posix(),
+            "expected_name": sample.expected_name,
+            "recognized_name": result.item_name,
+            "raw_item_text": result.raw_item_text,
+            "correct": is_correct,
+            "elapsed_seconds": elapsed,
+        })
 
     sample_count = len(sample_reports)
     accuracy = (correct_count / sample_count) if sample_count else 0.0
@@ -145,6 +143,7 @@ def _install_tessdata_package(package_name: str, target_dir: Path) -> str:
         "--no-deps",
         "--target",
         str(target_dir),
+        "--",
         package_name,
     ]
     try:
@@ -233,23 +232,21 @@ def main() -> int:
             run_report["package_name"] = package_name
             runs.append(run_report)
         except Exception as exc:
-            runs.append(
-                {
-                    "label": label,
-                    "package_name": package_name,
-                    "sample_count": 0,
-                    "correct_count": 0,
-                    "accuracy": 0.0,
-                    "elapsed_seconds": 0.0,
-                    "backend": {
-                        "tesseract_version": "",
-                        "tessdata_dir": None,
-                        "languages": [],
-                    },
-                    "samples": [],
-                    "error": str(exc),
-                }
-            )
+            runs.append({
+                "label": label,
+                "package_name": package_name,
+                "sample_count": 0,
+                "correct_count": 0,
+                "accuracy": 0.0,
+                "elapsed_seconds": 0.0,
+                "backend": {
+                    "tesseract_version": "",
+                    "tessdata_dir": None,
+                    "languages": [],
+                },
+                "samples": [],
+                "error": str(exc),
+            })
 
     fast_report = next(
         (report for report in runs if report["label"] == "fast-eng"),


### PR DESCRIPTION
🎯 **What:** Fixes a vulnerability in `scripts/benchmark_tessdata_models.py` where a dynamic variable (`package_name`) could inject arbitrary arguments into the `pip install` subprocess command.
⚠️ **Risk:** If an attacker can control the `package_name` variable (e.g., if the `MODEL_PACKAGES` dictionary is modified to include untrusted external input in the future), they could inject malicious options like `-i <malicious_index>` into the `pip install` command to execute arbitrary code during benchmarking.
🛡️ **Solution:** Inserts the POSIX end-of-options delimiter (`--`) right before `package_name` in the `command` list. This guarantees that `pip` strictly treats any subsequent text as a positional argument (the package to install) and ignores any embedded command-line flags.

---
*PR created automatically by Jules for task [16688647377459715634](https://jules.google.com/task/16688647377459715634) started by @Ven0m0*