### PR TITLE
⚡ Optimize redundant API calls in APIDataSource

### DIFF
--- a/src/autoscrapper/api/datasource.py
+++ b/src/autoscrapper/api/datasource.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Literal
 
@@ -14,6 +14,7 @@ from .client import ArcTrackerClient
 
 if TYPE_CHECKING:
     from ..scanner.types import ScanStats
+    from .models import StashData
 
 _log = logging.getLogger(__name__)
 
@@ -28,10 +29,12 @@ class APIDataSource:
     client: ArcTrackerClient
     actions: ActionMap
     dry_run: bool = False
+    _stash_data_cache: StashData | None = field(default=None, init=False)
 
     def fetch_stash(self) -> list[ItemActionResult]:
         """Fetch stash from API and convert to scan results."""
-        stash_data = self.client.get_all_stash_items()
+        self._stash_data_cache = self.client.get_all_stash_items()
+        stash_data = self._stash_data_cache
 
         if stash_data.api_error:
             _log.warning("api: Failed to fetch stash: %s", stash_data.api_error)
@@ -94,7 +97,11 @@ class APIDataSource:
         """Get scan stats for API fetch."""
         from ..scanner.types import ScanStats
 
-        stash_data = self.client.get_all_stash_items()
+        if getattr(self, "_stash_data_cache", None) is not None:
+            stash_data = self._stash_data_cache
+        else:
+            stash_data = self.client.get_all_stash_items()
+            self._stash_data_cache = stash_data
 
         return ScanStats(
             items_in_stash=stash_data.used_slots if not stash_data.api_error else None,


### PR DESCRIPTION
💡 **What:**
Added caching logic utilizing a new private `_stash_data_cache` field to `APIDataSource` which saves the stash items fetched from the API instead of refetching them.

🎯 **Why:**
To eliminate a redundant API call when getting stash properties. Previously, `fetch_stash()` and `get_stats()` would sequentially fetch the same API data, causing two round trips. This optimizes the data retrieval logic without changing the expected return behavior.

📊 **Measured Improvement:**
Utilizing a benchmark simulating a 100ms API latency, the total execution time of both operations dropped by over 50% (from ~0.2s down to ~0.1s), validating that network request delays were halved.

---
*PR created automatically by Jules for task [9555994521990513800](https://jules.google.com/task/9555994521990513800) started by @Ven0m0*