### PR TITLE
🧪 [testing improvement] Add tests for RateLimitState calculations

### DIFF
--- a/tests/autoscrapper/api/test_models.py
+++ b/tests/autoscrapper/api/test_models.py
@@ -1,0 +1,66 @@
+"""Tests for ArcTracker API models."""
+
+import time
+from unittest.mock import patch
+from autoscrapper.api.models import RateLimitState
+
+
+def test_is_rate_limited():
+    """Test is_rate_limited property logic."""
+    # Scenario 1: Remaining > 0
+    state = RateLimitState(remaining=10, reset_timestamp=time.time() + 100)
+    assert state.is_rate_limited is False
+
+    # Scenario 2: Remaining <= 0, but reset_timestamp has passed
+    with patch("time.time", return_value=1000.0):
+        state = RateLimitState(remaining=0, reset_timestamp=900.0)
+        assert state.is_rate_limited is False
+
+    # Scenario 3: Remaining <= 0, and reset_timestamp is in the future
+    with patch("time.time", return_value=1000.0):
+        state = RateLimitState(remaining=0, reset_timestamp=1100.0)
+        assert state.is_rate_limited is True
+
+
+def test_seconds_until_reset():
+    """Test seconds_until_reset property logic."""
+    # Scenario 1: reset_timestamp is in the future
+    with patch("time.time", return_value=1000.0):
+        state = RateLimitState(reset_timestamp=1010.5)
+        assert state.seconds_until_reset == 10.5
+
+    # Scenario 2: reset_timestamp is in the past
+    with patch("time.time", return_value=1000.0):
+        state = RateLimitState(reset_timestamp=990.0)
+        assert state.seconds_until_reset == 0.0
+
+
+def test_time_until_next_request():
+    """Test time_until_next_request calculation logic."""
+    # Scenario 1: Not rate limited, cooldown still active
+    # last_request = 995, now = 1000, min_interval = 8.0 -> cooldown = 3.0
+    with patch("time.time", return_value=1000.0):
+        state = RateLimitState(remaining=10, last_request_timestamp=995.0)
+        assert state.time_until_next_request(min_interval=8.0) == 3.0
+
+    # Scenario 2: Not rate limited, cooldown passed
+    # last_request = 990, now = 1000, min_interval = 8.0 -> cooldown = 0.0
+    with patch("time.time", return_value=1000.0):
+        state = RateLimitState(remaining=10, last_request_timestamp=990.0)
+        assert state.time_until_next_request(min_interval=8.0) == 0.0
+
+    # Scenario 3: Rate limited, cooldown < reset_time
+    # last_request = 995, now = 1000, min_interval = 8.0 -> cooldown = 3.0
+    # reset_timestamp = 1010 -> seconds_until_reset = 10.0
+    # Expected: max(3.0, 10.0) = 10.0
+    with patch("time.time", return_value=1000.0):
+        state = RateLimitState(remaining=0, last_request_timestamp=995.0, reset_timestamp=1010.0)
+        assert state.time_until_next_request(min_interval=8.0) == 10.0
+
+    # Scenario 4: Rate limited, cooldown > reset_time
+    # last_request = 995, now = 1000, min_interval = 8.0 -> cooldown = 3.0
+    # reset_timestamp = 1001 -> seconds_until_reset = 1.0
+    # Expected: max(3.0, 1.0) = 3.0
+    with patch("time.time", return_value=1000.0):
+        state = RateLimitState(remaining=0, last_request_timestamp=995.0, reset_timestamp=1001.0)
+        assert state.time_until_next_request(min_interval=8.0) == 3.0


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for `RateLimitState` calculations in `src/autoscrapper/api/models.py`.
📊 **Coverage:** Added tests for `is_rate_limited`, `seconds_until_reset`, and `time_until_next_request` covering:
- Happy paths for active and inactive rate limits.
- Edge cases where timestamps have already passed.
- Calculation logic for wait times considering both minimum intervals and rate limit resets.
✨ **Result:** Improved reliability and coverage of the API model logic, ensuring that rate-limiting calculations are deterministic and correct.

---
*PR created automatically by Jules for task [2519188319035549090](https://jules.google.com/task/2519188319035549090) started by @Ven0m0*