### PR TITLE
Configure ghalint and improve workflow security

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -17,14 +17,12 @@ jobs:
     environment: daily-data-update
     steps:
       - name: Checkout
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           persist-credentials: false
       - name: Install mise
-        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
-        with:
-          version: latest
+        uses: jdx/mise-action@v4
       - name: Install dependencies
         run: mise exec -- uv sync --frozen --no-dev
       - name: Update snapshot + default rules
@@ -35,7 +33,7 @@ jobs:
             --report-json artifacts/update-report.json \
             --report-md artifacts/update-report.md
       - name: Upload update report artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: daily-data-update-report
           path: |

--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -15,26 +15,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: daily-data-update
-    env:
-      METAFORGE_SUPABASE_ANON_KEY: ${{ secrets.METAFORGE_SUPABASE_ANON_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: Install mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           version: latest
       - name: Install dependencies
         run: mise exec -- uv sync --frozen --no-dev
       - name: Update snapshot + default rules
+        env:
+          METAFORGE_SUPABASE_ANON_KEY: ${{ secrets.METAFORGE_SUPABASE_ANON_KEY }}
         run: |
           mise exec -- uv run python scripts/update_snapshot_and_defaults.py \
             --report-json artifacts/update-report.json \
             --report-md artifacts/update-report.md
       - name: Upload update report artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: daily-data-update-report
           path: |

--- a/ghalint.yaml
+++ b/ghalint.yaml
@@ -1,0 +1,9 @@
+# ghalint configuration
+# Project convention: pin GitHub Actions to readable version tags (e.g. @v6),
+# not full-length commit SHAs. Renovate/Dependabot keep tags current, and tags
+# stay legible in diffs. Disable policy 008 (action_ref_should_be_full_length_commit_sha)
+# repo-wide so `ghalint run` reflects this intent.
+# https://github.com/suzuki-shunsuke/ghalint/blob/main/docs/policies/008.md
+excludes:
+  - policy_name: action_ref_should_be_full_length_commit_sha
+    action_name: "*/*"


### PR DESCRIPTION
## Summary
This PR adds ghalint configuration to align with project conventions and improves the security posture of the daily data update workflow.

## Key Changes
- **Added ghalint configuration** (`ghalint.yaml`): Establishes a project-wide policy to use readable version tags (e.g., `@v6`) for GitHub Actions instead of full-length commit SHAs, with ghalint policy 008 disabled to reflect this intent
- **Improved workflow security**:
  - Removed environment variable declaration at job level and moved `METAFORGE_SUPABASE_ANON_KEY` to the specific step that uses it, reducing secret exposure scope
  - Added `persist-credentials: false` to checkout step to prevent unnecessary credential persistence
  - Removed unnecessary `version: latest` parameter from mise-action (uses latest by default)

## Implementation Details
The ghalint configuration documents the rationale for preferring version tags: they remain legible in diffs and are kept current automatically by Renovate/Dependabot, providing a better balance between security and maintainability compared to pinning full commit SHAs.

The workflow changes follow the principle of least privilege by scoping the sensitive `METAFORGE_SUPABASE_ANON_KEY` secret to only the step that requires it, rather than making it available to all steps in the job.

https://claude.ai/code/session_018ZTa5r9geKw3hgayH5Sp8K