### PR TITLE
fix: resolve committed merge-conflict markers across repo

### DIFF
--- a/.kilo/kilo.json
+++ b/.kilo/kilo.json
@@ -15,7 +15,7 @@
     "doom_loop": "deny"
   },
   "agent": {
-    "compaction": { "model": "kilo-auto/free" },
+    "compaction": { "model": "kilo-auto/free" }
   },
   "provider": {
     "openai": {
@@ -32,7 +32,7 @@
     "@gotgenes/opencode-agent-identity@3.0.1",
     "opencode-agent-skills@0.6.5",
     "@openspoon/subtask2@0.3.9",
-		"@tarquinen/opencode-dcp@3.1.9",
+    "@tarquinen/opencode-dcp@3.1.9",
     "@morphllm/opencode-morph-plugin@2.0.9",
     "opencode-agent-memory@0.2.0",
     "superpowers@git+https://github.com/obra/superpowers.git",
@@ -69,7 +69,7 @@
       "type": "remote",
       "url": "https://api.githubcopilot.com/mcp/",
       "enabled": true
-    }
+    },
     "exa": {
       "type": "remote",
       "url": "https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa",
@@ -78,19 +78,23 @@
     },
     "serena": {
       "type": "local",
-			"command": [
-				"uvx", "--from",
-				"git+https://github.com/oraios/serena",
-				"serena", "start-mcp-server",
-				"--context", "ide", "--project-from-cwd"
-			],
+      "command": [
+        "uvx",
+        "--from",
+        "git+https://github.com/oraios/serena",
+        "serena",
+        "start-mcp-server",
+        "--context",
+        "ide",
+        "--project-from-cwd"
+      ],
       "enabled": true
     },
     "octocode": {
       "type": "local",
       "command": ["npx", "-y", "octocode-mcp@latest"],
       "enabled": true
-    } 
+    }
   },
   "lsp": {
     "basedpyright": {
@@ -101,11 +105,11 @@
       "command": ["bash-language-server", "start"],
       "extensions": [".sh", ".bash", ".zsh"]
     },
-		"vtsls": {
+    "vtsls": {
       "command": ["vtsls", "--stdio"],
       "extensions": [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"],
       "initialization": { "preferences": { "importModuleSpecifierPreference": "relative" } }
-		},
+    },
     "rust": {
       "command": ["rust-analyzer"],
       "extensions": [".rs"]
@@ -134,12 +138,15 @@
       "command": ["vscode-css-language-server", "--stdio"],
       "extensions": [".css", ".scss", ".less"]
     },
-		"powershell": {
-			"command": [
-				"pwsh", "-NoLogo", "-NoProfile", "-Command",
-				"$module = Get-Module -ListAvailable PowerShellEditorServices | Sort-Object Version -Descending | Select-Object -First 1; if (-not $module) { throw 'PowerShellEditorServices is not installed. Run: Install-Module -Name PowerShellEditorServices -Scope CurrentUser' }; Import-Module $module.Path; Start-EditorServices -HostName 'Claude Code' -HostProfileId 'ClaudeCode' -HostVersion '1.0.0' -Stdio -BundledModulesPath (Split-Path $module.Path) -LogPath '/dev/null' -LogLevel 'None' -EnableConsoleRepl"
-			],
-			"extensions": [".ps1", ".psm1", ".psd1"]
+    "powershell": {
+      "command": [
+        "pwsh",
+        "-NoLogo",
+        "-NoProfile",
+        "-Command",
+        "$module = Get-Module -ListAvailable PowerShellEditorServices | Sort-Object Version -Descending | Select-Object -First 1; if (-not $module) { throw 'PowerShellEditorServices is not installed. Run: Install-Module -Name PowerShellEditorServices -Scope CurrentUser' }; Import-Module $module.Path; Start-EditorServices -HostName 'Claude Code' -HostProfileId 'ClaudeCode' -HostVersion '1.0.0' -Stdio -BundledModulesPath (Split-Path $module.Path) -LogPath '/dev/null' -LogLevel 'None' -EnableConsoleRepl"
+      ],
+      "extensions": [".ps1", ".psm1", ".psd1"]
     }
   },
   "compaction": { "auto": true, "prune": true },

--- a/.mcp.json
+++ b/.mcp.json
@@ -37,18 +37,18 @@
         "--project-from-cwd"
       ]
     },
-		"github": {
-			"type": "http",
-			"url": "https://api.githubcopilot.com/mcp/"
-		},
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    },
     "context7": {
       "type": "http",
       "url": "https://mcp.context7.com/mcp"
     },
-		"exa": {
-			"type": "http",
-			"url": "https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa",
-			"headers": { "x-api-key": "{env:EXA_API_KEY}" }
-		}
+    "exa": {
+      "type": "http",
+      "url": "https://mcp.exa.ai/mcp?tools=web_search_exa,web_search_advanced_exa,get_code_context_exa,crawling_exa",
+      "headers": { "x-api-key": "{env:EXA_API_KEY}" }
+    }
   }
 }

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/autoscrapper/api/client.py
+++ b/src/autoscrapper/api/client.py
@@ -129,7 +129,7 @@ class ArcTrackerClient:
         if "headers" in kwargs:
             headers.update(kwargs.pop("headers"))
         if require_auth:
-            headers["X-App-Key"] = self.app_key  # type: ignore[assignment]
+            headers["X-App-Key"] = self.app_key or ""
             headers["Authorization"] = f"Bearer {self.user_key}"
 
         try:

--- a/src/autoscrapper/items/items_rules.default.json
+++ b/src/autoscrapper/items/items_rules.default.json
@@ -1,25 +1,11 @@
 {
   "metadata": {
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-    "generatedAt": "2026-06-01T19:14:32.356646Z",
+    "generatedAt": "2026-06-04T20:00:22.300607Z",
     "data": {
-      "lastUpdated": "2026-06-01T19:14:32.340613Z",
-      "source": "https://metaforge.app/arc-raiders",
-      "version": "autoscrapper-data-1"
-    },
-    "itemCount": 581,
-<<<<<<< HEAD
-=======
-=======
-    "generatedAt": "2026-05-08T14:33:29.567880Z",
-    "data": {
-      "lastUpdated": "2026-05-08T14:33:29.557671Z",
+      "lastUpdated": "2026-06-04T20:00:22.288473Z",
       "source": "https://metaforge.app/arc-raiders/api",
       "version": "autoscrapper-data-1",
-      "itemCount": 606,
+      "itemCount": 615,
       "questCount": 100,
       "dataSources": {
         "items": {
@@ -32,7 +18,7 @@
           "fallback": {
             "repository": "https://github.com/RaidTheory/arcraiders-data",
             "archive": "https://github.com/RaidTheory/arcraiders-data/archive/refs/heads/main.zip",
-            "supplementalCount": 33,
+            "supplementalCount": 34,
             "error": null
           },
           "arctrackerEnrichment": {
@@ -43,7 +29,7 @@
           },
           "fieldLevelMerge": {
             "enabled": true,
-            "entriesEnriched": 367,
+            "entriesEnriched": 371,
             "sources": [
               "raidtheory-fallback",
               "arctracker"
@@ -68,7 +54,7 @@
           "wikiEnrichment": {
             "url": "https://arcraiders.wiki/wiki/Loot",
             "available": true,
-            "enrichedCount": 98,
+            "enrichedCount": 91,
             "error": null,
             "fields": [
               "wikiUses"
@@ -138,9 +124,7 @@
       },
       "hasPriceOverrides": false
     },
-    "itemCount": 606,
->>>>>>> origin/main
->>>>>>> origin/main
+    "itemCount": 615,
     "allQuestsCompleted": true
   },
   "items": [
@@ -1236,7 +1220,7 @@
       "value": 300,
       "action": "keep",
       "analysis": [
-        "Used in 5 crafting recipes",
+        "Used in 6 crafting recipes",
         "Common crafting ingredient",
         "Override: treat 'Your Call' as Keep"
       ]
@@ -1278,19 +1262,9 @@
       "value": 10000,
       "action": "keep",
       "analysis": [
-<<<<<<< HEAD
-        "Weapon - review based on your current loadout",
-        "Consider tier and your play style",
-=======
-<<<<<<< HEAD
-        "Weapon - review based on your current loadout",
-        "Consider tier and your play style",
-=======
         "Tier 2 variant - review based on your current loadout",
         "Consider tier and your play style",
         "Base weapon: Canto",
->>>>>>> origin/main
->>>>>>> origin/main
         "Override: treat 'Your Call' as Keep"
       ]
     },
@@ -1300,19 +1274,9 @@
       "value": 13000,
       "action": "keep",
       "analysis": [
-<<<<<<< HEAD
-        "Weapon - review based on your current loadout",
-        "Consider tier and your play style",
-=======
-<<<<<<< HEAD
-        "Weapon - review based on your current loadout",
-        "Consider tier and your play style",
-=======
         "Tier 3 variant - review based on your current loadout",
         "Consider tier and your play style",
         "Base weapon: Canto",
->>>>>>> origin/main
->>>>>>> origin/main
         "Override: treat 'Your Call' as Keep"
       ]
     },
@@ -1322,19 +1286,9 @@
       "value": 17000,
       "action": "keep",
       "analysis": [
-<<<<<<< HEAD
-        "Weapon - review based on your current loadout",
-        "Consider tier and your play style",
-=======
-<<<<<<< HEAD
-        "Weapon - review based on your current loadout",
-        "Consider tier and your play style",
-=======
         "Tier 4 variant - review based on your current loadout",
         "Consider tier and your play style",
         "Base weapon: Canto",
->>>>>>> origin/main
->>>>>>> origin/main
         "Override: treat 'Your Call' as Keep"
       ]
     },
@@ -1609,48 +1563,6 @@
       ]
     },
     {
-      "id": "crash-mat",
-      "name": "Crash Mat",
-      "value": 1200,
-      "action": "keep",
-      "analysis": [
-        "Consumable item - grenades, healing items, etc.",
-        "Review based on your current inventory needs",
-        "Override: treat 'Your Call' as Keep"
-      ]
-    },
-    {
-      "id": "crash-mat-blueprint",
-      "name": "Crash Mat Blueprint",
-      "value": 5000,
-      "action": "keep",
-      "analysis": [
-        "Legendary rarity - extremely valuable",
-        "Keep all legendaries"
-      ]
-    },
-    {
-      "id": "crash-mat",
-      "name": "Crash Mat",
-      "value": 1200,
-      "action": "keep",
-      "analysis": [
-        "Consumable item - grenades, healing items, etc.",
-        "Review based on your current inventory needs",
-        "Override: treat 'Your Call' as Keep"
-      ]
-    },
-    {
-      "id": "crash-mat-blueprint",
-      "name": "Crash Mat Blueprint",
-      "value": 5000,
-      "action": "keep",
-      "analysis": [
-        "Legendary rarity - extremely valuable",
-        "Keep all legendaries"
-      ]
-    },
-    {
       "id": "crimson-racer-aviator-colour",
       "name": "Crimson Racer (Aviator Colour)",
       "value": 0,
@@ -1683,20 +1595,6 @@
     {
       "id": "dam-control-center-tower-key",
       "name": "Dam Control Tower Key",
-<<<<<<< HEAD
-=======
-      "value": 100,
-      "action": "keep",
-      "analysis": [
-        "Key - opens locked areas and containers",
-        "Review based on areas you want to access",
-        "Override: treat 'Your Call' as Keep"
-      ]
-    },
-    {
-      "id": "dam-control-tower-key",
-      "name": "Dam Control Tower Key",
->>>>>>> origin/main
       "value": 100,
       "action": "keep",
       "analysis": [
@@ -1945,26 +1843,6 @@
       "id": "dodgers-note",
       "name": "Dodger's Note",
       "value": 100,
-      "action": "sell",
-      "analysis": [
-        "No immediate use found",
-        "Safe to sell or recycle"
-      ]
-    },
-    {
-      "id": "dockmasters-detector",
-      "name": "Dockmaster\u2019s Detector",
-      "value": 1000,
-      "action": "sell",
-      "analysis": [
-        "No immediate use found",
-        "Safe to sell or recycle"
-      ]
-    },
-    {
-      "id": "dockmasters-detector",
-      "name": "Dockmaster\u2019s Detector",
-      "value": 1000,
       "action": "sell",
       "analysis": [
         "No immediate use found",
@@ -2224,16 +2102,13 @@
     },
     {
       "id": "extended-barrel-i",
-<<<<<<< HEAD
       "name": "Extended Barrel I ",
-=======
-      "name": "Extended Barrel I",
->>>>>>> origin/main
       "value": 1000,
       "action": "keep",
       "analysis": [
-        "Weapon - review based on your current loadout",
+        "Tier 1 variant - review based on your current loadout",
         "Consider tier and your play style",
+        "Base weapon: Extended Barrel I",
         "Override: treat 'Your Call' as Keep"
       ]
     },
@@ -2243,8 +2118,9 @@
       "value": 3000,
       "action": "keep",
       "analysis": [
-        "Weapon - review based on your current loadout",
+        "Tier 2 variant - review based on your current loadout",
         "Consider tier and your play style",
+        "Base weapon: Extended Barrel",
         "Override: treat 'Your Call' as Keep"
       ]
     },
@@ -2256,6 +2132,18 @@
       "analysis": [
         "Legendary rarity - extremely valuable",
         "Keep all legendaries"
+      ]
+    },
+    {
+      "id": "extended-barrel-iii",
+      "name": "Extended Barrel III",
+      "value": 5000,
+      "action": "keep",
+      "analysis": [
+        "Tier 3 variant - review based on your current loadout",
+        "Consider tier and your play style",
+        "Base weapon: Extended Barrel",
+        "Override: treat 'Your Call' as Keep"
       ]
     },
     {
@@ -2442,19 +2330,7 @@
       "value": 50,
       "action": "keep",
       "analysis": [
-<<<<<<< HEAD
-        "Used in 3 crafting recipes",
-        "Common crafting ingredient",
-        "Override: treat 'Your Call' as Keep"
-=======
-<<<<<<< HEAD
-        "Used in 3 crafting recipes",
-        "Common crafting ingredient",
-        "Override: treat 'Your Call' as Keep"
-=======
         "Required for hideout upgrade: Gear Bench (Level 1), Medical Lab (Level 1)"
->>>>>>> origin/main
->>>>>>> origin/main
       ]
     },
     {
@@ -2714,18 +2590,8 @@
       "value": 100,
       "action": "recycle",
       "analysis": [
-<<<<<<< HEAD
-        "Recycles into: 6x Plastic Parts, 6x Rubber Parts",
-        "Recycle value: Components (660 coins) worth MORE than Item (100 coins)"
-=======
-<<<<<<< HEAD
-        "Recycles into: 6x Plastic Parts, 6x Rubber Parts",
-        "Recycle value: Components (660 coins) worth MORE than Item (100 coins)"
-=======
         "Recycles into: 6x Plastic Parts",
         "Recycle value: Components (360 coins) worth MORE than Item (100 coins)"
->>>>>>> origin/main
->>>>>>> origin/main
       ]
     },
     {
@@ -2989,15 +2855,7 @@
       "value": 700,
       "action": "keep",
       "analysis": [
-<<<<<<< HEAD
-        "Used in 21 crafting recipes",
-=======
-<<<<<<< HEAD
-        "Used in 21 crafting recipes",
-=======
-        "Used in 4 crafting recipes",
->>>>>>> origin/main
->>>>>>> origin/main
+        "Used in 5 crafting recipes",
         "Rare crafting material",
         "Override: treat 'Your Call' as Keep"
       ]
@@ -3072,16 +2930,7 @@
       "value": 1000,
       "action": "keep",
       "analysis": [
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-        "Used in 2 crafting recipes",
-        "Rare crafting material",
-        "Override: treat 'Your Call' as Keep"
-=======
         "Required for hideout upgrade: Gear Bench (Level 2)"
->>>>>>> origin/main
       ]
     },
     {
@@ -3467,10 +3316,6 @@
       ]
     },
     {
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
       "id": "library-book",
       "name": "Book",
       "value": 100,
@@ -3481,8 +3326,6 @@
       ]
     },
     {
->>>>>>> origin/main
->>>>>>> origin/main
       "id": "lidar-scanner",
       "name": "Lidar Scanner",
       "value": 100,
@@ -3778,16 +3621,7 @@
       "value": 640,
       "action": "keep",
       "analysis": [
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-        "Used in 35 crafting recipes",
-        "Common crafting ingredient",
-        "Override: treat 'Your Call' as Keep"
-=======
         "Required for hideout upgrade: Gunsmith (Level 2)"
->>>>>>> origin/main
       ]
     },
     {
@@ -3807,15 +3641,7 @@
       "value": 700,
       "action": "keep",
       "analysis": [
-<<<<<<< HEAD
-        "Used in 26 crafting recipes",
-=======
-<<<<<<< HEAD
-        "Used in 26 crafting recipes",
-=======
         "Used in 7 crafting recipes",
->>>>>>> origin/main
->>>>>>> origin/main
         "Rare crafting material",
         "Override: treat 'Your Call' as Keep"
       ]
@@ -4235,16 +4061,7 @@
       "value": 60,
       "action": "keep",
       "analysis": [
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-        "Used in 19 crafting recipes",
-        "Common crafting ingredient",
-        "Override: treat 'Your Call' as Keep"
-=======
         "Required for hideout upgrade: Gear Bench (Level 1), Utility Station (Level 1)"
->>>>>>> origin/main
       ]
     },
     {
@@ -4380,10 +4197,6 @@
       ]
     },
     {
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
       "id": "precision-gimbal",
       "name": "Precision Gimbal",
       "value": 100,
@@ -4394,8 +4207,6 @@
       ]
     },
     {
->>>>>>> origin/main
->>>>>>> origin/main
       "id": "prickly-pear",
       "name": "Prickly Pear",
       "value": 640,
@@ -4563,35 +4374,50 @@
       ]
     },
     {
-      "id": "rascal-ii",
-      "name": "Rascal II ",
-      "value": 0,
+      "id": "rascal-i",
+      "name": "Rascal I",
+      "value": 7000,
       "action": "keep",
       "analysis": [
-        "Weapon - review based on your current loadout",
+        "Tier 1 variant - review based on your current loadout",
         "Consider tier and your play style",
+        "Base weapon: Rascal",
+        "Override: treat 'Your Call' as Keep"
+      ]
+    },
+    {
+      "id": "rascal-ii",
+      "name": "Rascal II ",
+      "value": 10000,
+      "action": "keep",
+      "analysis": [
+        "Tier 2 variant - review based on your current loadout",
+        "Consider tier and your play style",
+        "Base weapon: Rascal II",
         "Override: treat 'Your Call' as Keep"
       ]
     },
     {
       "id": "rascal-iii",
       "name": "Rascal III",
-      "value": 0,
+      "value": 13000,
       "action": "keep",
       "analysis": [
-        "Weapon - review based on your current loadout",
+        "Tier 3 variant - review based on your current loadout",
         "Consider tier and your play style",
+        "Base weapon: Rascal",
         "Override: treat 'Your Call' as Keep"
       ]
     },
     {
       "id": "rascal-iv",
       "name": "Rascal IV",
-      "value": 0,
+      "value": 17000,
       "action": "keep",
       "analysis": [
-        "Weapon - review based on your current loadout",
+        "Tier 4 variant - review based on your current loadout",
         "Consider tier and your play style",
+        "Base weapon: Rascal",
         "Override: treat 'Your Call' as Keep"
       ]
     },
@@ -4808,11 +4634,7 @@
     },
     {
       "id": "riven-tides-classifed-records-keycard",
-<<<<<<< HEAD
       "name": "Riven Tides Classifed Records Keycard",
-=======
-      "name": "Riven Tides Classified Records Keycard",
->>>>>>> origin/main
       "value": 100,
       "action": "keep",
       "analysis": [
@@ -4822,10 +4644,6 @@
       ]
     },
     {
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
       "id": "riven-tides-classified-records-keycard",
       "name": "Riven Tides Classified Records Keycard",
       "value": 100,
@@ -4837,8 +4655,6 @@
       ]
     },
     {
->>>>>>> origin/main
->>>>>>> origin/main
       "id": "riven-tides-crane-house-keycard",
       "name": "Riven Tides Crane House Keycard",
       "value": 100,
@@ -5851,15 +5667,7 @@
     {
       "id": "surge-coil",
       "name": "Surge Coil",
-<<<<<<< HEAD
-      "value": 0,
-=======
-<<<<<<< HEAD
-      "value": 0,
-=======
       "value": 2100,
->>>>>>> origin/main
->>>>>>> origin/main
       "action": "keep",
       "analysis": [
         "Rare rarity",
@@ -6328,18 +6136,8 @@
       "value": 5000,
       "action": "keep",
       "analysis": [
-<<<<<<< HEAD
-        "Epic rarity",
-        "May have future use - review carefully",
-=======
-<<<<<<< HEAD
-        "Epic rarity",
-        "May have future use - review carefully",
-=======
         "Used in 1 crafting recipes",
         "Rare crafting material",
->>>>>>> origin/main
->>>>>>> origin/main
         "Override: treat 'Your Call' as Keep"
       ]
     },

--- a/src/autoscrapper/progress/data/items.json
+++ b/src/autoscrapper/progress/data/items.json
@@ -67,7 +67,7 @@
       "electrical-components": 1,
       "wires": 1
     },
-    "wikiUses": "Workshop Gear Bench 3 (5x) Utility Station 3 (5x) Projects Expedition 1 (5x) Expedition 2 (5x) Expedition 3 (5x)"
+    "wikiUses": "Workshop Gear Bench 3 (5x) Utility Station 3 (5x) Projects Expedition 1 (5x) Expedition 2 (5x) Expedition 3 (5x) Expedition 4 (5x)"
   },
   {
     "id": "advanced-mechanical-components",
@@ -102,8 +102,7 @@
     "recipe": null,
     "recyclesInto": {
       "assorted-seeds": 3
-    },
-    "wikiUses": "Projects Avian Alarm (8x)"
+    }
   },
   {
     "id": "agave-juice",
@@ -429,7 +428,7 @@
     "recyclesInto": {
       "metal-parts": 2
     },
-    "wikiUses": "Workshop Explosives Station 1 (6x) Medical Lab 1 (6x) Utility Station 1 (6x) Quests Clearer Skies (3x) Shoring Up Defenses (1x) Projects Expedition 1 (80x) Expedition 2 (80x) Expedition 3 (80x)"
+    "wikiUses": "Workshop Explosives Station 1 (6x) Medical Lab 1 (6x) Utility Station 1 (6x) Quests Clearer Skies (3x) Shoring Up Defenses (1x) Projects Expedition 1 (80x) Expedition 2 (80x) Expedition 3 (80x) Expedition 4 (80x)"
   },
   {
     "id": "arc-circuitry",
@@ -495,7 +494,7 @@
     "recyclesInto": {
       "arc-alloy": 2
     },
-    "wikiUses": "Workshop Refiner 2 (5x)"
+    "wikiUses": "Workshop Refiner 2 (5x) Projects Expedition 4 (20x)"
   },
   {
     "id": "arc-performance-steel",
@@ -752,19 +751,10 @@
     "updatedAt": "2026-04-07T20:56:46.075515+00:00",
     "recipe": null,
     "recyclesInto": {
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-      "arc-alloy": 3,
-      "advanced-mechanical-components": 1
-    }
-=======
       "advanced-mechanical-components": 1,
       "arc-alloy": 3
     },
     "wikiUses": "Workshop Gear Bench 3 (6x) Quests Settled in Full (1x) Projects Trophy Display (5x)"
->>>>>>> origin/main
   },
   {
     "id": "battery",
@@ -1570,7 +1560,7 @@
     "recyclesInto": {
       "plastic-parts": 3
     },
-    "wikiUses": "Projects Avian Alarm (20x)"
+    "wikiUses": "Projects Expedition 4 (15x)"
   },
   {
     "id": "cans-backpack-attachment",
@@ -1594,15 +1584,7 @@
     "weightKg": 0,
     "stackSize": 1,
     "craftBench": null,
-<<<<<<< HEAD
     "updatedAt": "2026-05-24T21:05:14.834373+00:00",
-=======
-<<<<<<< HEAD
-    "updatedAt": "2026-05-24T21:05:14.834373+00:00",
-=======
-    "updatedAt": "2026-04-06T09:47:44.400185+00:00",
->>>>>>> origin/main
->>>>>>> origin/main
     "recipe": null,
     "recyclesInto": null
   },
@@ -1636,20 +1618,7 @@
     "stackSize": 1,
     "craftBench": "Gunsmith III",
     "updatedAt": "2026-04-03T23:45:42.68568+00:00",
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-    "recipe": {
-      "advanced-mechanical-components": 1,
-      "medium-gun-parts": 2
-    },
-<<<<<<< HEAD
-=======
-=======
     "recipe": null,
->>>>>>> origin/main
->>>>>>> origin/main
     "recyclesInto": {
       "advanced-mechanical-components": 2,
       "medium-gun-parts": 2
@@ -1665,20 +1634,7 @@
     "stackSize": 1,
     "craftBench": null,
     "updatedAt": "2026-04-03T23:48:53.265546+00:00",
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-    "recipe": {
-      "advanced-mechanical-components": 1,
-      "medium-gun-parts": 2
-    },
-<<<<<<< HEAD
-=======
-=======
     "recipe": null,
->>>>>>> origin/main
->>>>>>> origin/main
     "recyclesInto": {
       "advanced-mechanical-components": 2,
       "medium-gun-parts": 3
@@ -1694,20 +1650,7 @@
     "stackSize": 1,
     "craftBench": null,
     "updatedAt": "2026-04-03T23:51:27.380366+00:00",
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-    "recipe": {
-      "advanced-mechanical-components": 2,
-      "medium-gun-parts": 2
-    },
-<<<<<<< HEAD
-=======
-=======
     "recipe": null,
->>>>>>> origin/main
->>>>>>> origin/main
     "recyclesInto": {
       "advanced-mechanical-components": 3,
       "medium-gun-parts": 3
@@ -1752,7 +1695,7 @@
     "updatedAt": "2026-01-31T06:29:13.011643+00:00",
     "recipe": null,
     "recyclesInto": null,
-    "wikiUses": "Workshop Explosives Station 1 (50x) Projects Expedition 3 (100x)"
+    "wikiUses": "Workshop Explosives Station 1 (50x) Projects Expedition 3 (100x) Expedition 4 (100x)"
   },
   {
     "id": "coffee-pot",
@@ -1898,7 +1841,7 @@
       "arc-alloy": 2,
       "crude-explosives": 2
     },
-    "wikiUses": "Quests Collision Course (1x) Projects Avian Alarm (3x)"
+    "wikiUses": "Quests Collision Course (1x)"
   },
   {
     "id": "compensator-i",
@@ -2101,34 +2044,6 @@
     }
   },
   {
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-    "id": "crash-mat",
-    "name": "Crash Mat",
-    "type": "Quick Use",
-    "rarity": "uncommon",
-    "value": 1200,
-    "weightKg": 0.3,
-    "stackSize": 5,
-    "craftBench": "Utility Station II",
-    "updatedAt": "2026-05-05T12:56:01.174817+00:00",
-    "recipe": {
-      "electrical-components": 1,
-      "durable-cloth": 1
-    },
-    "recyclesInto": {
-      "fabric": 6,
-      "plastic-parts": 3
-    }
-  },
-  {
-<<<<<<< HEAD
-=======
-=======
->>>>>>> origin/main
->>>>>>> origin/main
     "id": "crash-mat-blueprint",
     "name": "Crash Mat Blueprint",
     "type": "Blueprint",
@@ -2137,15 +2052,7 @@
     "weightKg": 0,
     "stackSize": 1,
     "craftBench": null,
-<<<<<<< HEAD
     "updatedAt": "2026-05-25T09:44:11.57557+00:00",
-=======
-<<<<<<< HEAD
-    "updatedAt": "2026-05-25T09:44:11.57557+00:00",
-=======
-    "updatedAt": "2026-05-05T12:55:41.066338+00:00",
->>>>>>> origin/main
->>>>>>> origin/main
     "recipe": null,
     "recyclesInto": null
   },
@@ -2522,15 +2429,7 @@
   },
   {
     "id": "dockmasters-detector",
-<<<<<<< HEAD
-    "name": "Dockmaster\u2019s Detector",
-=======
-<<<<<<< HEAD
-    "name": "Dockmaster\u2019s Detector",
-=======
     "name": "Dockmaster’s Detector",
->>>>>>> origin/main
->>>>>>> origin/main
     "type": "Gadget",
     "rarity": "uncommon",
     "value": 1000,
@@ -2586,15 +2485,7 @@
     "weightKg": 0,
     "stackSize": 1,
     "craftBench": null,
-<<<<<<< HEAD
     "updatedAt": "2026-05-24T21:02:38.780319+00:00",
-=======
-<<<<<<< HEAD
-    "updatedAt": "2026-05-24T21:02:38.780319+00:00",
-=======
-    "updatedAt": "2026-04-06T09:43:59.559957+00:00",
->>>>>>> origin/main
->>>>>>> origin/main
     "recipe": null,
     "recyclesInto": null
   },
@@ -2675,7 +2566,7 @@
     "recyclesInto": {
       "fabric": 6
     },
-    "wikiUses": "Workshop Medical Lab 2 (5x) Quests Doctor's Orders (1x) Projects Expedition 1 (35x) Expedition 2 (35x) Expedition 3 (30x)"
+    "wikiUses": "Workshop Medical Lab 2 (5x) Quests Doctor's Orders (1x) Projects Expedition 1 (35x) Expedition 2 (35x) Expedition 3 (30x) Expedition 4 (30x)"
   },
   {
     "id": "electrical-components",
@@ -2695,7 +2586,7 @@
       "plastic-parts": 3,
       "rubber-parts": 3
     },
-    "wikiUses": "Workshop Gear Bench 2 (5x) Utility Station 2 (5x) Quests Fragmented Logs (1x) Projects Expedition 1 (30x) Expedition 2 (20x) Expedition 3 (20x)"
+    "wikiUses": "Workshop Gear Bench 2 (5x) Utility Station 2 (5x) Quests Fragmented Logs (1x) Projects Expedition 1 (30x) Expedition 2 (20x) Expedition 3 (20x) Expedition 4 (20x)"
   },
   {
     "id": "empty-wine-bottle",
@@ -2787,7 +2678,7 @@
       "magnet": 2,
       "processor": 2
     },
-    "wikiUses": "Projects Expedition 1 (1x) Expedition 2 (1x) Expedition 3 (1x) Trophy Display (5x)"
+    "wikiUses": "Projects Expedition 1 (1x) Expedition 2 (1x) Expedition 3 (1x) Expedition 4 (2x) Trophy Display (5x)"
   },
   {
     "id": "expired-pasta",
@@ -2872,21 +2763,21 @@
   },
   {
     "id": "extended-barrel-i",
-<<<<<<< HEAD
     "name": "Extended Barrel I ",
-=======
-    "name": "Extended Barrel I",
->>>>>>> origin/main
     "type": "Modification",
     "rarity": "uncommon",
     "value": 1000,
     "weightKg": 0.25,
-<<<<<<< HEAD
     "stackSize": 1,
-    "craftBench": null,
+    "craftBench": "weapon_bench",
     "updatedAt": "2026-05-24T09:17:44.091994+00:00",
-    "recipe": null,
-    "recyclesInto": null
+    "recipe": {
+      "metal-parts": 6,
+      "wires": 3
+    },
+    "recyclesInto": {
+      "metal-parts": 5
+    }
   },
   {
     "id": "extended-barrel-ii",
@@ -2896,15 +2787,15 @@
     "value": 3000,
     "weightKg": 0.5,
     "stackSize": 1,
-    "craftBench": null,
+    "craftBench": "weapon_bench",
     "updatedAt": "2026-05-20T10:36:55.499969+00:00",
     "recipe": {
       "mechanical-components": 3,
-      "wires-recipe": 6
+      "wires": 6
     },
     "recyclesInto": {
       "mechanical-components": 1,
-      "wires-recipe": 1
+      "wires": 1
     }
   },
   {
@@ -2917,16 +2808,10 @@
     "stackSize": 1,
     "craftBench": null,
     "updatedAt": "2026-05-24T09:07:00.230069+00:00",
-=======
-    "stackSize": 1,
-    "craftBench": null,
-    "updatedAt": "2026-05-24T09:17:44.091994+00:00",
->>>>>>> origin/main
     "recipe": null,
     "recyclesInto": null
   },
   {
-<<<<<<< HEAD
     "id": "extended-barrel-recipe",
     "name": "Extended Barrel III Blueprint",
     "type": "Blueprint",
@@ -2949,80 +2834,10 @@
     "stackSize": 1,
     "craftBench": "Gunsmith I",
     "updatedAt": "2026-05-19T17:56:50.224648+00:00",
-=======
-    "id": "extended-barrel-ii",
-    "name": "Extended Barrel II",
-    "type": "Modification",
-    "rarity": "rare",
-    "value": 3000,
-    "weightKg": 0.5,
-    "stackSize": 1,
-<<<<<<< HEAD
-    "craftBench": null,
-    "updatedAt": "2026-05-20T10:36:55.499969+00:00",
->>>>>>> origin/main
-    "recipe": {
-      "mechanical-components": 3,
-      "wires-recipe": 6
-    },
-    "recyclesInto": {
-      "mechanical-components": 1,
-      "wires-recipe": 1
-    }
-  },
-  {
-<<<<<<< HEAD
-=======
-    "id": "extended-barrel-ii-blueprint",
-    "name": "Extended Barrel II Blueprint",
-    "type": "Blueprint",
-    "rarity": "legendary",
-    "value": 5000,
-    "weightKg": 0,
-    "stackSize": 1,
-    "craftBench": null,
-    "updatedAt": "2026-05-24T09:07:00.230069+00:00",
     "recipe": null,
     "recyclesInto": null
   },
   {
-    "id": "extended-barrel-recipe",
-    "name": "Extended Barrel III Blueprint",
-    "type": "Blueprint",
-    "rarity": "legendary",
-    "value": 5000,
-    "weightKg": 0,
-    "stackSize": 1,
-    "craftBench": null,
-    "updatedAt": "2026-05-19T17:49:58.291628+00:00",
-    "recipe": null,
-    "recyclesInto": null
-  },
-  {
-    "id": "extended-barrel",
-    "name": "Extended Barrel III",
-    "type": "Modification",
-    "rarity": "epic",
-    "value": 5000,
-    "weightKg": 0.75,
-    "stackSize": 1,
-    "craftBench": "Gunsmith I",
-    "updatedAt": "2026-05-19T17:56:50.224648+00:00",
-=======
-    "craftBench": "weapon_bench",
-    "updatedAt": "2026-01-31T06:29:13.011643+00:00",
->>>>>>> origin/main
-    "recipe": {
-      "mod-components": 2,
-      "wires": 8
-    },
-    "recyclesInto": {
-      "mod-components": 1,
-      "wires": 1
-    }
-  },
-  {
->>>>>>> origin/main
     "id": "extended-light-mag-i",
     "name": "Extended Light Mag I",
     "type": "Modification",
@@ -3401,8 +3216,7 @@
     "recipe": null,
     "recyclesInto": {
       "assorted-seeds": 2
-    },
-    "wikiUses": "Projects Avian Alarm (10x)"
+    }
   },
   {
     "id": "film-reel",
@@ -3534,14 +3348,7 @@
     "value": 640,
     "weightKg": 1,
     "stackSize": 1,
-<<<<<<< HEAD
-    "craftBench": null,
-<<<<<<< HEAD
-=======
-=======
     "craftBench": "in_raid",
->>>>>>> origin/main
->>>>>>> origin/main
     "updatedAt": "2026-05-07T17:35:33.710226+00:00",
     "recipe": {
       "air-freshener": 1,
@@ -3623,15 +3430,7 @@
     "recipe": null,
     "recyclesInto": {
       "plastic-parts": 6,
-<<<<<<< HEAD
-      "rubber-parts-recipe": 6
-=======
-<<<<<<< HEAD
-      "rubber-parts-recipe": 6
-=======
       "rubber-parts": 6
->>>>>>> origin/main
->>>>>>> origin/main
     }
   },
   {
@@ -4387,7 +4186,7 @@
       "metal-parts": 5,
       "voltage-converter": 1
     },
-    "wikiUses": "Projects Expedition 3 (3x)"
+    "wikiUses": "Projects Expedition 3 (3x) Expedition 4 (3x)"
   },
   {
     "id": "industrial-magnet",
@@ -4674,33 +4473,6 @@
       "assorted-seeds": 3
     },
     "wikiUses": "Workshop Scrappy 3 (3x)"
-  },
-  {
-    "id": "leviathans-crown-ship-model",
-    "name": "\"Leviathan's Crown\" Ship Model",
-    "type": "Trinket",
-    "rarity": "legendary",
-    "value": 10000,
-    "weightKg": 0.5,
-    "stackSize": 1,
-    "craftBench": null,
-    "updatedAt": "2026-05-02T15:16:39.123489+00:00",
-    "recipe": null,
-    "recyclesInto": null,
-    "wikiUses": "Projects Avian Alarm (1x)"
-  },
-  {
-    "id": "leviathans-crown-ship-model",
-    "name": "\"Leviathan's Crown\" Ship Model",
-    "type": "Trinket",
-    "rarity": "legendary",
-    "value": 10000,
-    "weightKg": 0.5,
-    "stackSize": 1,
-    "craftBench": null,
-    "updatedAt": "2026-05-02T15:16:39.123489+00:00",
-    "recipe": null,
-    "recyclesInto": null
   },
   {
     "id": "leviathans-crown-ship-model",
@@ -5243,7 +5015,7 @@
     "updatedAt": "2026-01-31T06:29:13.011643+00:00",
     "recipe": null,
     "recyclesInto": null,
-    "wikiUses": "Workshop Gunsmith 1 (20x) Refiner 1 (60x) Projects Expedition 1 (150x) Expedition 2 (150x) Expedition 3 (150x)"
+    "wikiUses": "Workshop Gunsmith 1 (20x) Refiner 1 (60x) Projects Expedition 1 (150x) Expedition 2 (150x) Expedition 3 (150x) Expedition 4 (150x)"
   },
   {
     "id": "microscope",
@@ -5305,20 +5077,11 @@
     "weightKg": 0.3,
     "stackSize": 10,
     "craftBench": null,
-<<<<<<< HEAD
     "updatedAt": "2026-05-24T21:08:36.221228+00:00",
-=======
-<<<<<<< HEAD
-    "updatedAt": "2026-05-24T21:08:36.221228+00:00",
-=======
-    "updatedAt": "2026-05-02T09:03:57.247506+00:00",
->>>>>>> origin/main
->>>>>>> origin/main
     "recipe": null,
     "recyclesInto": {
       "assorted-seeds": 3
-    },
-    "wikiUses": "Projects Avian Alarm (12x)"
+    }
   },
   {
     "id": "motor",
@@ -5505,7 +5268,8 @@
     "recipe": null,
     "recyclesInto": {
       "chemicals": 3
-    }
+    },
+    "wikiUses": "Projects Expedition 4 (25x)"
   },
   {
     "id": "olives",
@@ -5808,7 +5572,7 @@
       "battery": 2,
       "wires": 6
     },
-    "wikiUses": "Quests Movie Night (1x)"
+    "wikiUses": "Quests Movie Night (1x) Projects Expedition 4 (1x)"
   },
   {
     "id": "poster-natural-wonder",
@@ -5888,31 +5652,6 @@
     }
   },
   {
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-    "id": "powered-descender",
-    "name": "Powered Descender",
-    "type": "Gadget",
-    "rarity": "epic",
-    "value": 10000,
-    "weightKg": 5,
-    "stackSize": 1,
-    "craftBench": null,
-    "updatedAt": "2026-05-05T12:56:35.094503+00:00",
-    "recipe": null,
-    "recyclesInto": {
-      "advanced-electrical-components": 1,
-      "arc-circuitry": 2
-    }
-  },
-  {
-<<<<<<< HEAD
-=======
-=======
->>>>>>> origin/main
->>>>>>> origin/main
     "id": "powered-descender-blueprint",
     "name": "Powered Descender Blueprint",
     "type": "Blueprint",
@@ -5921,15 +5660,7 @@
     "weightKg": 0,
     "stackSize": 1,
     "craftBench": null,
-<<<<<<< HEAD
     "updatedAt": "2026-05-20T10:46:23.877509+00:00",
-=======
-<<<<<<< HEAD
-    "updatedAt": "2026-05-20T10:46:23.877509+00:00",
-=======
-    "updatedAt": "2026-05-05T12:18:34.332002+00:00",
->>>>>>> origin/main
->>>>>>> origin/main
     "recipe": null,
     "recyclesInto": null
   },
@@ -5962,15 +5693,7 @@
     "weightKg": 0.2,
     "stackSize": 10,
     "craftBench": null,
-<<<<<<< HEAD
     "updatedAt": "2026-05-25T11:58:38.439991+00:00",
-=======
-<<<<<<< HEAD
-    "updatedAt": "2026-05-25T11:58:38.439991+00:00",
-=======
-    "updatedAt": "2026-04-15T14:50:47.786663+00:00",
->>>>>>> origin/main
->>>>>>> origin/main
     "recipe": null,
     "recyclesInto": {
       "assorted-seeds": 3
@@ -6157,15 +5880,8 @@
     "stackSize": 1,
     "craftBench": "Gunsmith II",
     "updatedAt": "2026-06-01T10:42:59.404609+00:00",
-    "recipe": {
-      "advanced-mechanical-components": 2,
-      "heavy-gun-parts": 3,
-      "canister": 5
-    },
-    "recyclesInto": {
-      "advanced-mechanical-components": 1,
-      "heavy-gun-parts": 2
-    }
+    "recipe": null,
+    "recyclesInto": null
   },
   {
     "id": "rascal-blueprint",
@@ -6182,22 +5898,15 @@
   },
   {
     "id": "rascal-ii",
-<<<<<<< HEAD
     "name": "Rascal II ",
-=======
-    "name": "Rascal II",
->>>>>>> origin/main
     "type": "Weapon",
     "rarity": "rare",
-    "value": 0,
+    "value": 10000,
     "weightKg": 4,
     "stackSize": 1,
-    "craftBench": null,
+    "craftBench": "weapon_bench",
     "updatedAt": "2026-05-24T21:50:44.350759+00:00",
-    "recipe": {
-      "advanced-mechanical-components": 1,
-      "heavy-gun-parts": 1
-    },
+    "recipe": null,
     "recyclesInto": {
       "advanced-mechanical-components": 2,
       "heavy-gun-parts": 2
@@ -6208,15 +5917,12 @@
     "name": "Rascal III",
     "type": "Weapon",
     "rarity": "rare",
-    "value": 0,
+    "value": 13000,
     "weightKg": 4,
     "stackSize": 1,
-    "craftBench": null,
+    "craftBench": "weapon_bench",
     "updatedAt": "2026-05-24T21:51:39.782937+00:00",
-    "recipe": {
-      "advanced-mechanical-components": 1,
-      "heavy-gun-parts": 1
-    },
+    "recipe": null,
     "recyclesInto": {
       "advanced-mechanical-components": 2,
       "heavy-gun-parts": 3
@@ -6227,15 +5933,12 @@
     "name": "Rascal IV",
     "type": "Weapon",
     "rarity": "rare",
-    "value": 0,
+    "value": 17000,
     "weightKg": 4,
     "stackSize": 1,
     "craftBench": "Gunsmith II",
     "updatedAt": "2026-05-24T21:52:11.362064+00:00",
-    "recipe": {
-      "advanced-mechanical-components": 2,
-      "heavy-gun-parts": 1
-    },
+    "recipe": null,
     "recyclesInto": {
       "advanced-mechanical-components": 3,
       "heavy-gun-parts": 3
@@ -6332,8 +6035,7 @@
     "craftBench": null,
     "updatedAt": "2026-01-31T06:29:13.011643+00:00",
     "recipe": null,
-    "recyclesInto": null,
-    "wikiUses": "Projects Avian Alarm (3x)"
+    "recyclesInto": null
   },
   {
     "id": "red-light-stick",
@@ -6538,11 +6240,7 @@
   },
   {
     "id": "riven-tides-classifed-records-keycard",
-<<<<<<< HEAD
     "name": "Riven Tides Classifed Records Keycard",
-=======
-    "name": "Riven Tides Classified Records Keycard",
->>>>>>> origin/main
     "type": "Key",
     "rarity": "uncommon",
     "value": 100,
@@ -6588,15 +6286,7 @@
     "weightKg": 0.5,
     "stackSize": 1,
     "craftBench": null,
-<<<<<<< HEAD
     "updatedAt": "2026-05-20T10:39:04.615594+00:00",
-=======
-<<<<<<< HEAD
-    "updatedAt": "2026-05-20T10:39:04.615594+00:00",
-=======
-    "updatedAt": "2026-04-30T08:43:30.097008+00:00",
->>>>>>> origin/main
->>>>>>> origin/main
     "recipe": null,
     "recyclesInto": null
   },
@@ -6724,8 +6414,7 @@
     "recipe": null,
     "recyclesInto": {
       "assorted-seeds": 1
-    },
-    "wikiUses": "Projects Avian Alarm (4x)"
+    }
   },
   {
     "id": "rope",
@@ -6949,15 +6638,7 @@
     "weightKg": 3,
     "stackSize": 3,
     "craftBench": null,
-<<<<<<< HEAD
     "updatedAt": "2026-05-21T18:57:15.222867+00:00",
-=======
-<<<<<<< HEAD
-    "updatedAt": "2026-05-21T18:57:15.222867+00:00",
-=======
-    "updatedAt": "2026-05-06T12:37:44.280528+00:00",
->>>>>>> origin/main
->>>>>>> origin/main
     "recipe": null,
     "recyclesInto": {
       "mechanical-components": 2,
@@ -6997,7 +6678,7 @@
       "metal-parts": 8,
       "steel-spring": 1
     },
-    "wikiUses": "Workshop Gunsmith 2 (3x) Projects Avian Alarm (8x)"
+    "wikiUses": "Workshop Gunsmith 2 (3x)"
   },
   {
     "id": "rusty-arc-steel",
@@ -7250,14 +6931,7 @@
     "value": 5000,
     "weightKg": 0.5,
     "stackSize": 1,
-<<<<<<< HEAD
-    "craftBench": null,
-<<<<<<< HEAD
-=======
-=======
     "craftBench": "weapon_bench",
->>>>>>> origin/main
->>>>>>> origin/main
     "updatedAt": "2026-05-07T17:35:15.002617+00:00",
     "recipe": {
       "mod-components": 2,
@@ -7485,16 +7159,8 @@
     "craftBench": null,
     "updatedAt": "2026-04-28T21:18:47.938347+00:00",
     "recipe": null,
-<<<<<<< HEAD
-    "recyclesInto": null
-=======
-<<<<<<< HEAD
-    "recyclesInto": null
-=======
     "recyclesInto": null,
-    "wikiUses": "Projects Avian Alarm (5x)"
->>>>>>> origin/main
->>>>>>> origin/main
+    "wikiUses": "Projects Expedition 4 (2x)"
   },
   {
     "id": "smoke-grenade",
@@ -7695,7 +7361,8 @@
     "recyclesInto": {
       "plastic-parts": 2,
       "rubber-parts": 3
-    }
+    },
+    "wikiUses": "Projects Expedition 4 (15x)"
   },
   {
     "id": "spectrometer",
@@ -8042,32 +7709,13 @@
     "name": "Surge Coil",
     "type": "Deployable",
     "rarity": "rare",
-<<<<<<< HEAD
-    "value": 0,
-=======
-<<<<<<< HEAD
-    "value": 0,
-=======
     "value": 2100,
->>>>>>> origin/main
->>>>>>> origin/main
     "weightKg": 0,
     "stackSize": 1,
     "craftBench": "Explosives Bench III",
     "updatedAt": "2026-04-01T15:47:24.211411+00:00",
     "recipe": {
       "electrical-components": 1,
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-      "sensors-recipe": 1,
-      "hornet-driver": 1
-    },
-    "recyclesInto": null
-<<<<<<< HEAD
-=======
-=======
       "hornet-driver": 1,
       "sensors": 1
     },
@@ -8075,8 +7723,6 @@
       "electrical-components": 1,
       "sensors": 1
     }
->>>>>>> origin/main
->>>>>>> origin/main
   },
   {
     "id": "surge-coil-blueprint",
@@ -8087,15 +7733,7 @@
     "weightKg": 0,
     "stackSize": 1,
     "craftBench": null,
-<<<<<<< HEAD
     "updatedAt": "2026-05-24T21:06:14.829654+00:00",
-=======
-<<<<<<< HEAD
-    "updatedAt": "2026-05-24T21:06:14.829654+00:00",
-=======
-    "updatedAt": "2026-04-06T09:45:52.854826+00:00",
->>>>>>> origin/main
->>>>>>> origin/main
     "recipe": null,
     "recyclesInto": null
   },
@@ -8310,15 +7948,7 @@
     "value": 5000,
     "weightKg": 4,
     "stackSize": 1,
-<<<<<<< HEAD
-    "craftBench": null,
-=======
-<<<<<<< HEAD
-    "craftBench": null,
-=======
     "craftBench": "equipment_bench",
->>>>>>> origin/main
->>>>>>> origin/main
     "updatedAt": "2026-04-30T06:51:54.741036+00:00",
     "recipe": {
       "advanced-electrical-components": 2,
@@ -8338,15 +7968,7 @@
     "weightKg": 0,
     "stackSize": 1,
     "craftBench": null,
-<<<<<<< HEAD
     "updatedAt": "2026-05-20T10:46:41.187256+00:00",
-=======
-<<<<<<< HEAD
-    "updatedAt": "2026-05-20T10:46:41.187256+00:00",
-=======
-    "updatedAt": "2026-04-30T06:50:49.008893+00:00",
->>>>>>> origin/main
->>>>>>> origin/main
     "recipe": null,
     "recyclesInto": null
   },
@@ -8553,7 +8175,7 @@
       "arc-alloy": 2,
       "chemicals": 2
     },
-    "wikiUses": "Workshop Medical Lab 2 (8x) Projects Avian Alarm (7x) Trophy Display (15x)"
+    "wikiUses": "Workshop Medical Lab 2 (8x) Projects Trophy Display (15x)"
   },
   {
     "id": "toaster",
@@ -8779,16 +8401,8 @@
     "recyclesInto": {
       "arc-circuitry": 1,
       "arc-motion-core": 1
-<<<<<<< HEAD
-    }
-=======
-<<<<<<< HEAD
-    }
-=======
     },
-    "wikiUses": "Projects Avian Alarm (2x)"
->>>>>>> origin/main
->>>>>>> origin/main
+    "wikiUses": "Projects Expedition 4 (5x)"
   },
   {
     "id": "turbo-pump",
@@ -8817,16 +8431,7 @@
     "craftBench": null,
     "updatedAt": "2026-04-28T12:54:12.347282+00:00",
     "recipe": null,
-<<<<<<< HEAD
     "recyclesInto": null
-=======
-<<<<<<< HEAD
-    "recyclesInto": null
-=======
-    "recyclesInto": null,
-    "wikiUses": "Projects Avian Alarm (5x)"
->>>>>>> origin/main
->>>>>>> origin/main
   },
   {
     "id": "unusable-weapon",
@@ -8859,7 +8464,7 @@
       "advanced-electrical-components": 1,
       "arc-circuitry": 2
     },
-    "wikiUses": "Projects Avian Alarm (1x)"
+    "wikiUses": "Projects Expedition 4 (3x)"
   },
   {
     "id": "vase",
@@ -8885,16 +8490,7 @@
     "craftBench": null,
     "updatedAt": "2026-04-28T14:48:53.389154+00:00",
     "recipe": null,
-<<<<<<< HEAD
     "recyclesInto": null
-=======
-<<<<<<< HEAD
-    "recyclesInto": null
-=======
-    "recyclesInto": null,
-    "wikiUses": "Projects Avian Alarm (5x)"
->>>>>>> origin/main
->>>>>>> origin/main
   },
   {
     "id": "venator-recipe",
@@ -9275,7 +8871,7 @@
     "recyclesInto": {
       "arc-alloy": 2
     },
-    "wikiUses": "Workshop Gunsmith 1 (8x) Quests The Trifecta (2x) Projects Trophy Display (20x)"
+    "wikiUses": "Workshop Gunsmith 2 (8x) Quests The Trifecta (2x) Projects Trophy Display (20x)"
   },
   {
     "id": "water-filter",
@@ -9291,8 +8887,7 @@
     "recyclesInto": {
       "canister": 3,
       "rubber-parts": 2
-    },
-    "wikiUses": "Projects Avian Alarm (3x)"
+    }
   },
   {
     "id": "water-pump",
@@ -9338,15 +8933,7 @@
     "weightKg": 0,
     "stackSize": 1,
     "craftBench": null,
-<<<<<<< HEAD
     "updatedAt": "2026-05-20T10:46:56.354189+00:00",
-=======
-<<<<<<< HEAD
-    "updatedAt": "2026-05-20T10:46:56.354189+00:00",
-=======
-    "updatedAt": "2026-05-05T12:15:27.138544+00:00",
->>>>>>> origin/main
->>>>>>> origin/main
     "recipe": null,
     "recyclesInto": null
   },
@@ -9534,19 +9121,6 @@
     "recyclesInto": null
   },
   {
-    "id": "dam-control-tower-key",
-    "name": "Dam Control Tower Key",
-    "type": "Key",
-    "rarity": "epic",
-    "value": 100,
-    "weightKg": 0.25,
-    "stackSize": 1,
-    "craftBench": null,
-    "updatedAt": "02/24/2026",
-    "recipe": null,
-    "recyclesInto": null
-  },
-  {
     "id": "damaged-snitch-scanner",
     "name": "Damaged Snitch Scanner",
     "type": "Recyclable",
@@ -9623,6 +9197,25 @@
     "updatedAt": "05/04/2026",
     "recipe": null,
     "recyclesInto": null
+  },
+  {
+    "id": "extended-barrel-iii",
+    "name": "Extended Barrel III",
+    "type": "Modification",
+    "rarity": "epic",
+    "value": 5000,
+    "weightKg": 0.5,
+    "stackSize": 1,
+    "craftBench": "weapon_bench",
+    "updatedAt": "01/13/2026",
+    "recipe": {
+      "mod-components": 2,
+      "wires": 8
+    },
+    "recyclesInto": {
+      "mod-components": 1,
+      "wires": 1
+    }
   },
   {
     "id": "first-wave-compass",
@@ -9844,6 +9437,26 @@
     "updatedAt": "05/04/2026",
     "recipe": null,
     "recyclesInto": null
+  },
+  {
+    "id": "rascal-i",
+    "name": "Rascal I",
+    "type": "Special",
+    "rarity": "rare",
+    "value": 7000,
+    "weightKg": 4,
+    "stackSize": 1,
+    "craftBench": "weapon_bench",
+    "updatedAt": "05/19/2026",
+    "recipe": {
+      "advanced-mechanical-components": 2,
+      "canister": 5,
+      "heavy-gun-parts": 3
+    },
+    "recyclesInto": {
+      "advanced-mechanical-components": 1,
+      "heavy-gun-parts": 2
+    }
   },
   {
     "id": "riven-tides-classified-records-keycard",

--- a/src/autoscrapper/progress/data/metadata.json
+++ b/src/autoscrapper/progress/data/metadata.json
@@ -1,20 +1,8 @@
 {
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-  "lastUpdated": "2026-06-01T19:14:32.340613Z",
-  "source": "https://metaforge.app/arc-raiders",
-  "version": "autoscrapper-data-1",
-  "itemCount": 581,
-  "questCount": 100,
-<<<<<<< HEAD
-=======
-=======
-  "lastUpdated": "2026-05-08T14:33:29.557671Z",
+  "lastUpdated": "2026-06-04T20:00:22.288473Z",
   "source": "https://metaforge.app/arc-raiders/api",
   "version": "autoscrapper-data-1",
-  "itemCount": 606,
+  "itemCount": 615,
   "questCount": 100,
   "dataSources": {
     "items": {
@@ -27,7 +15,7 @@
       "fallback": {
         "repository": "https://github.com/RaidTheory/arcraiders-data",
         "archive": "https://github.com/RaidTheory/arcraiders-data/archive/refs/heads/main.zip",
-        "supplementalCount": 33,
+        "supplementalCount": 34,
         "error": null
       },
       "arctrackerEnrichment": {
@@ -38,7 +26,7 @@
       },
       "fieldLevelMerge": {
         "enabled": true,
-        "entriesEnriched": 367,
+        "entriesEnriched": 371,
         "sources": [
           "raidtheory-fallback",
           "arctracker"
@@ -63,7 +51,7 @@
       "wikiEnrichment": {
         "url": "https://arcraiders.wiki/wiki/Loot",
         "available": true,
-        "enrichedCount": 98,
+        "enrichedCount": 91,
         "error": null,
         "fields": [
           "wikiUses"
@@ -131,7 +119,5 @@
       }
     }
   },
->>>>>>> origin/main
->>>>>>> origin/main
   "hasPriceOverrides": false
 }

--- a/src/autoscrapper/progress/data/quests.json
+++ b/src/autoscrapper/progress/data/quests.json
@@ -579,11 +579,7 @@
         "item": {
           "id": "extended-barrel",
           "icon": "https://cdn.metaforge.app/arc-raiders/icons/extended-barrel.webp",
-<<<<<<< HEAD
           "name": "Extended Barrel IIII",
-=======
-          "name": "Extended Barrel III",
->>>>>>> origin/main
           "rarity": "Epic",
           "item_type": "Modification"
         },
@@ -913,15 +909,7 @@
     ],
     "trader": "Celeste",
     "xp": 0,
-<<<<<<< HEAD
     "sortOrder": 7482.376892077519
-=======
-<<<<<<< HEAD
-    "sortOrder": 7482.376892077519
-=======
-    "sortOrder": 0
->>>>>>> origin/main
->>>>>>> origin/main
   },
   {
     "id": "back-on-top",
@@ -1021,15 +1009,7 @@
     ],
     "trader": "Apollo",
     "xp": 0,
-<<<<<<< HEAD
     "sortOrder": 703.6805381957103
-=======
-<<<<<<< HEAD
-    "sortOrder": 703.6805381957103
-=======
-    "sortOrder": 0
->>>>>>> origin/main
->>>>>>> origin/main
   },
   {
     "id": "bees",
@@ -1535,15 +1515,7 @@
     ],
     "trader": "TianWen",
     "xp": 0,
-<<<<<<< HEAD
     "sortOrder": 1040.3079231388663
-=======
-<<<<<<< HEAD
-    "sortOrder": 1040.3079231388663
-=======
-    "sortOrder": 0
->>>>>>> origin/main
->>>>>>> origin/main
   },
   {
     "id": "combat-recon",
@@ -2918,15 +2890,7 @@
     ],
     "trader": "Celeste",
     "xp": 0,
-<<<<<<< HEAD
     "sortOrder": 7009.632620481293
-=======
-<<<<<<< HEAD
-    "sortOrder": 7009.632620481293
-=======
-    "sortOrder": 0
->>>>>>> origin/main
->>>>>>> origin/main
   },
   {
     "id": "lost-in-transmission",
@@ -3885,15 +3849,7 @@
     ],
     "trader": "TianWen",
     "xp": 0,
-<<<<<<< HEAD
     "sortOrder": 7246.24880814753
-=======
-<<<<<<< HEAD
-    "sortOrder": 7246.24880814753
-=======
-    "sortOrder": 0
->>>>>>> origin/main
->>>>>>> origin/main
   },
   {
     "id": "safe-passage",
@@ -4033,15 +3989,7 @@
     ],
     "trader": "Apollo",
     "xp": 0,
-<<<<<<< HEAD
     "sortOrder": 422.07582107905125
-=======
-<<<<<<< HEAD
-    "sortOrder": 422.07582107905125
-=======
-    "sortOrder": 0
->>>>>>> origin/main
->>>>>>> origin/main
   },
   {
     "id": "snap-and-salvage",

--- a/src/autoscrapper/progress/data/quests_by_trader.json
+++ b/src/autoscrapper/progress/data/quests_by_trader.json
@@ -1,26 +1,8 @@
 {
-<<<<<<< HEAD
-  "generatedAt": "2026-06-01T19:14:32.340231Z",
-=======
-<<<<<<< HEAD
-  "generatedAt": "2026-06-01T19:14:32.340231Z",
-=======
-  "generatedAt": "2026-05-08T14:33:29.557470Z",
->>>>>>> origin/main
->>>>>>> origin/main
+  "generatedAt": "2026-06-04T20:00:22.288164Z",
   "source": "quests.json",
   "traders": {
     "Celeste": [
-      {
-        "id": "a-wrench-in-the-works",
-        "name": "A Wrench in the Works",
-        "sortOrder": 0
-      },
-      {
-        "id": "line-in-the-sand",
-        "name": "Line in the Sand",
-        "sortOrder": 0
-      },
       {
         "id": "a-bad-feeling",
         "name": "A Bad Feeling",
@@ -130,59 +112,28 @@
         "id": "turnabout",
         "name": "Turnabout",
         "sortOrder": 6307.955576058115
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
       },
       {
         "id": "line-in-the-sand",
         "name": "Line in the Sand",
         "sortOrder": 7009.632620481293
-<<<<<<< HEAD
-=======
-=======
->>>>>>> origin/main
->>>>>>> origin/main
       },
       {
         "id": "keeping-an-eye-out",
         "name": "Keeping An Eye Out",
         "sortOrder": 7116.778716162711
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
       },
       {
         "id": "a-wrench-in-the-works",
         "name": "A Wrench in the Works",
         "sortOrder": 7482.376892077519
-<<<<<<< HEAD
-=======
-=======
->>>>>>> origin/main
->>>>>>> origin/main
       }
     ],
     "TianWen": [
       {
         "id": "collision-course",
         "name": "Collision Course",
-<<<<<<< HEAD
         "sortOrder": 1040.3079231388663
-=======
-<<<<<<< HEAD
-        "sortOrder": 1040.3079231388663
-=======
-        "sortOrder": 0
-      },
-      {
-        "id": "safe-harbor",
-        "name": "Safe Harbor",
-        "sortOrder": 0
->>>>>>> origin/main
->>>>>>> origin/main
       },
       {
         "id": "the-right-tool",
@@ -260,20 +211,11 @@
         "sortOrder": 7185.630885955289
       },
       {
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
         "id": "safe-harbor",
         "name": "Safe Harbor",
         "sortOrder": 7246.24880814753
       },
       {
-<<<<<<< HEAD
-=======
-=======
->>>>>>> origin/main
->>>>>>> origin/main
         "id": "settled-in-full",
         "name": "Settled in Full",
         "sortOrder": 7431.071956110197
@@ -448,10 +390,6 @@
     ],
     "Apollo": [
       {
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
         "id": "shoring-up-defenses",
         "name": "Shoring up Defenses",
         "sortOrder": 422.07582107905125
@@ -460,19 +398,6 @@
         "id": "battening-down",
         "name": "Battening Down",
         "sortOrder": 703.6805381957103
-<<<<<<< HEAD
-=======
-=======
-        "id": "battening-down",
-        "name": "Battening Down",
-        "sortOrder": 0
-      },
-      {
-        "id": "shoring-up-defenses",
-        "name": "Shoring up Defenses",
-        "sortOrder": 0
->>>>>>> origin/main
->>>>>>> origin/main
       },
       {
         "id": "safe-passage",

--- a/src/autoscrapper/progress/data_update.py
+++ b/src/autoscrapper/progress/data_update.py
@@ -260,9 +260,7 @@ def _write_sources_config(path: Path, config: SupabaseConfig) -> None:
         "sourcePage": METAFORGE_APP_URL,
         "supabaseUrl": config.url,
         "supabaseAnonKey": config.anon_key,
-        "lastDiscoveredAt": datetime.now(timezone.utc)
-        .isoformat()
-        .replace("+00:00", "Z"),
+        "lastDiscoveredAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
@@ -292,9 +290,7 @@ def _discover_supabase_config(*, force: bool = False) -> SupabaseConfig:
         return _discovered_supabase_config
 
     page = _fetch_text(METAFORGE_APP_URL, accept="text/html,application/xhtml+xml")
-    supabase_url = _normalize_supabase_rest_url(
-        _extract_public_env_value(page, "PUBLIC_SUPABASE_URL")
-    )
+    supabase_url = _normalize_supabase_rest_url(_extract_public_env_value(page, "PUBLIC_SUPABASE_URL"))
     anon_key = _extract_public_env_value(page, "PUBLIC_SUPABASE_ANON_KEY")
     _discovered_supabase_config = SupabaseConfig(
         url=supabase_url,
@@ -354,22 +350,13 @@ def _fetch_supabase_all(table: str, sources_path: Path) -> List[dict]:
         discovered = _discover_supabase_config(force=True)
         if discovered == supabase_config:
             raise DownloadError(
-                "Supabase auth failed and Metaforge page discovery returned "
-                "the same public Supabase config."
+                "Supabase auth failed and Metaforge page discovery returned the same public Supabase config."
             ) from exc
         if configured.persist_discovery:
             _write_sources_config(sources_path, discovered)
         return _fetch_supabase_all_with_config(table, discovered)
 
 
-def _build_component_map(components: List[dict]) -> Dict[str, Dict[str, int]]:
-    component_map: Dict[str, Dict[str, int]] = {}
-    for component in components:
-        item_id = component.get("item_id")
-        component_id = component.get("component_id")
-        quantity = component.get("quantity")
-        if not item_id or not component_id or quantity is None:
-=======
 def _fetch_arctracker_quests() -> list[dict]:
     """Fetch all quests from arctracker.io public API."""
     url = f"{ARCTRACKER_BASE_URL}/api/quests"
@@ -754,7 +741,6 @@ def _normalize_component_values(value: object) -> dict[str, int] | None:
     for raw_item_id, raw_quantity in value_d.items():
         item_id = _normalize_external_id(raw_item_id)
         if item_id is None:
->>>>>>> origin/main
             continue
         try:
             quantity = int(raw_quantity)
@@ -1133,13 +1119,11 @@ def _build_quests_by_trader(quests: list[dict]) -> dict[str, list[dict]]:
     by_trader: dict[str, list[dict]] = {}
     for quest in quests:
         trader = quest.get("trader") or "Unknown"
-        by_trader.setdefault(trader, []).append(
-            {
-                "id": quest.get("id"),
-                "name": quest.get("name"),
-                "sortOrder": quest.get("sortOrder", 0),
-            }
-        )
+        by_trader.setdefault(trader, []).append({
+            "id": quest.get("id"),
+            "name": quest.get("name"),
+            "sortOrder": quest.get("sortOrder", 0),
+        })
 
     for trader, quests_list in by_trader.items():
         quests_list.sort(key=lambda q: q.get("sortOrder") or 0)
@@ -1248,7 +1232,6 @@ def _enrich_items_with_wiki(items: list[dict], uses_map: dict[str, str]) -> tupl
 def update_data_snapshot(data_dir: Path | None = None, *, use_arclens: bool = False) -> dict:
     data_dir = data_dir or DATA_DIR
     (data_dir / "static").mkdir(parents=True, exist_ok=True)
-    sources_path = _sources_path(data_dir)
 
     metaforge_items: list[dict] | None = None
     metaforge_quests: list[dict] | None = None
@@ -1265,17 +1248,6 @@ def update_data_snapshot(data_dir: Path | None = None, *, use_arclens: bool = Fa
         metaforge_quests_error = str(exc)
         _log.warning("MetaForge quests unavailable: %s", exc)
 
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
->>>>>>> origin/main
-    components = _fetch_supabase_all("arc_item_components", sources_path)
-    recycle_components = _fetch_supabase_all(
-        "arc_item_recycle_components", sources_path
-    )
-<<<<<<< HEAD
-=======
-=======
     fallback_items: list[dict] = []
     fallback_quests: list[dict] = []
     fallback_error: str | None = None
@@ -1284,8 +1256,6 @@ def update_data_snapshot(data_dir: Path | None = None, *, use_arclens: bool = Fa
     except DownloadError as exc:
         fallback_error = str(exc)
         _log.warning("RaidTheory fallback unavailable: %s", exc)
->>>>>>> origin/main
->>>>>>> origin/main
 
     # Map fallback items/quests for field-level merging (preserve for later use)
     mapped_fallback_items = (

--- a/src/autoscrapper/progress/recipe_utils.py
+++ b/src/autoscrapper/progress/recipe_utils.py
@@ -10,5 +10,5 @@ def build_reverse_recipe_index(items: list[dict]) -> dict[str, list[str]]:
             continue
         for ingredient_id in recipe.keys():
             used_by = reverse_index.setdefault(ingredient_id, [])
-            used_by.append(item.get("id", ""))
+            used_by.append(item.get("id") or "")
     return reverse_index

--- a/src/autoscrapper/tui/app.py
+++ b/src/autoscrapper/tui/app.py
@@ -334,37 +334,29 @@ class HomeScreen(MenuScreen):
 
 class MaintenanceMenuScreen(MenuScreen):
     def __init__(self) -> None:
-        items = [
+        super().__init__("Maintenance", [], default_key="1")
+
+    def _refresh_items(self) -> None:
+        update_used = bool(getattr(self.app, "_snapshot_update_used", False))
+        self.items = [
             MenuItem(
                 "1",
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
                 "Update game data snapshot",
                 lambda screen: cast("AutoScrapperApp", screen.app)._open_snapshot_update(),
                 disabled=update_used,
             ),
             MenuItem(
                 "2",
->>>>>>> origin/main
->>>>>>> origin/main
                 "Reset saved progress",
                 lambda screen: screen.app.push_screen(ResetProgressScreen()),
             ),
             MenuItem(
-                "2",
+                "3",
                 "Reset rules to default",
                 lambda screen: screen.app.push_screen(ResetRulesScreen()),
             ),
             MenuItem("0", "Back", lambda screen: screen.app.pop_screen()),
         ]
-<<<<<<< HEAD
-        super().__init__("Maintenance", items, default_key="1")
-=======
-<<<<<<< HEAD
-        super().__init__("Maintenance", items, default_key="1")
-=======
 
     def on_mount(self) -> None:
         self._refresh_items()
@@ -373,8 +365,6 @@ class MaintenanceMenuScreen(MenuScreen):
     def on_screen_resume(self, _event: events.ScreenResume) -> None:
         self._refresh_items()
         super().on_screen_resume(_event)
->>>>>>> origin/main
->>>>>>> origin/main
 
 
 class AutoScrapperApp(App[None]):

--- a/src/autoscrapper/tui/app.py
+++ b/src/autoscrapper/tui/app.py
@@ -15,7 +15,7 @@ from textual.widgets import Footer, OptionList, Static
 from textual.widgets.option_list import Option
 
 from .common import AppScreen
-from .maintenance import ResetProgressScreen, ResetRulesScreen
+from .maintenance import ResetProgressScreen, ResetRulesScreen, UpdateSnapshotScreen
 from .progress import (
     launch_edit_workshops,
     launch_generate_rules,
@@ -378,6 +378,7 @@ class AutoScrapperApp(App[None]):
         super().__init__()
         self._start_screen = start_screen
         self._scan_dry_run = scan_dry_run
+        self._snapshot_update_used = False
 
     def on_mount(self) -> None:
         self.push_screen(HomeScreen())
@@ -535,6 +536,12 @@ class AutoScrapperApp(App[None]):
             MenuItem("0", "Back", lambda screen: screen.app.pop_screen()),
         ]
         return MenuScreen("Settings", items, default_key="1")
+
+    def _open_snapshot_update(self) -> None:
+        if self._snapshot_update_used:
+            return
+        self._snapshot_update_used = True
+        self.push_screen(UpdateSnapshotScreen())
 
     def _maintenance_menu(self) -> MenuScreen:
         return MaintenanceMenuScreen()

--- a/src/autoscrapper/tui/maintenance.py
+++ b/src/autoscrapper/tui/maintenance.py
@@ -7,10 +7,6 @@ from textual.widgets import Button, Footer, Static
 from .common import AppScreen, MessageScreen
 from ..config import reset_progress_settings
 from ..core.item_actions import ITEM_RULES_CUSTOM_PATH
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
 from ..progress.data_update import DownloadError, update_data_snapshot
 
 
@@ -57,8 +53,6 @@ class UpdateSnapshotScreen(AppScreen):
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "back":
             self.app.pop_screen()
->>>>>>> origin/main
->>>>>>> origin/main
 
 
 class ResetProgressScreen(AppScreen):


### PR DESCRIPTION
## Problem

`main` (commit `6a00dcc`, via the "Upstream (#414)" / "#410" syncs) has **unresolved, nested merge-conflict markers committed into 8 files**. The repo can't be imported or parsed in its current state — which means even with the mise fix in #416, the **Daily Data Update** workflow would still fail: its script imports `progress/data_update.py`, which doesn't parse.

Affected files:
- `progress/data_update.py` (workflow's core dependency)
- `tui/app.py`, `tui/maintenance.py`
- `progress/data/{items,quests,quests_by_trader,metadata}.json`, `items/items_rules.default.json` (generated)

## Resolution

**Code (resolved by hand):**
- **`data_update.py`** — kept the fork's arctracker + RaidTheory fallback path **and** the complete Supabase source-discovery helpers. Dropped the **incomplete/unwired** supabase component fetch (`components`/`recycle_components` were assigned but never consumed) and the **truncated, never-called** `_build_component_map`. Component data already arrives with MetaForge items via `includeComponents=true`.
- **`app.py` / `maintenance.py`** — restored the intended `MaintenanceMenuScreen` (`_refresh_items` pattern, correct menu keys) and the `UpdateSnapshotScreen` import.

**Generated data (regenerated via the updater script, *not* hand-merged):**
- Ran `scripts/update_snapshot_and_defaults.py` to regenerate the 4 data JSONs + default rules (615 items, 100 quests).

**Pre-existing bug (surfaced once the suite could run again):**
- `recipe_utils.build_reverse_recipe_index`: `item.get("id", "")` returned `None` for an explicit `id=None`; changed to `item.get("id") or ""` to match the documented test intent.

## Validation
- `ruff check` — clean
- `basedpyright src/` — 0 errors, 0 warnings
- `pytest` — **460 passed, 2 skipped**

## ⚠️ Needs maintainer review (judgment calls)
1. **Supabase component feature was incomplete WIP** ("Changes before error encountered"). I removed its broken wiring but **kept the 13 source-discovery helper functions** (complete, currently unwired) so the feature can be finished later. If that work should instead be completed now or removed entirely, let me know.
2. **Generated JSON** reflects current live MetaForge data, replacing the conflicted snapshot. The daily workflow will keep these fresh going forward.

Companion to #416 (the workflow's mise fix); this PR makes the repo actually parseable/runnable so that workflow can succeed end-to-end.

https://claude.ai/code/session_018ZTa5r9geKw3hgayH5Sp8K

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZTa5r9geKw3hgayH5Sp8K)_