### PR TITLE
Fix git push strategy in daily data update workflow

### DIFF
--- a/.github/workflows/daily-data-update.yml
+++ b/.github/workflows/daily-data-update.yml
@@ -66,9 +66,7 @@ jobs:
               for file_path in changed_files:
                   print(f" - {file_path}")
           else:
-              print(
-              "No substantive tracked changes (timestamp-only updates ignored)."
-          )
+              print("No substantive tracked changes (timestamp-only updates ignored).")
 
           with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
               output.write(f"has_changes={'true' if has_changes else 'false'}\n")
@@ -95,7 +93,12 @@ jobs:
             exit 0
           fi
           git commit -m "chore(data): daily Metaforge snapshot + default rules"
-          git push --force-with-lease origin HEAD:bot/daily-data-update
+          # The runner checks out main at depth 1, so it has no remote-tracking
+          # ref for bot/daily-data-update. --force-with-lease would expect the
+          # branch to be absent and get rejected on every run after the first,
+          # so use a plain force push. The concurrency group serializes runs and
+          # the branch is owned exclusively by this workflow.
+          git push --force origin HEAD:bot/daily-data-update
           echo "has_commit=true" >> "$GITHUB_OUTPUT"
       - name: Create or update pull request
         if: steps.commit_push.outputs.has_commit == 'true'


### PR DESCRIPTION
## Summary
Updated the daily data update workflow to use a plain force push instead of `--force-with-lease` when pushing the bot branch, along with a minor code formatting fix.

## Changes
- **Git push strategy**: Changed from `git push --force-with-lease` to `git push --force` for the `bot/daily-data-update` branch
  - Added detailed comment explaining why: the shallow checkout (depth 1) means the runner has no remote-tracking ref for the branch, causing `--force-with-lease` to be rejected on every run after the first
  - The concurrency group serializes workflow runs and the branch is owned exclusively by this workflow, making a plain force push safe
- **Code formatting**: Fixed multi-line print statement to be on a single line for better readability

https://claude.ai/code/session_011EKoLifpr1gx8xfS6jGjTr