### PR TITLE
Fix preprocess_for_ocr Bug 1 & 2 regression test name

### DIFF
--- a/tests/autoscrapper/ocr/test_inventory_vision.py
+++ b/tests/autoscrapper/ocr/test_inventory_vision.py
@@ -87,7 +87,7 @@ def _solid_bgr(h, w, color=(128, 128, 128)):
 
 
 class TestPreprocessForOcr:
-    def test_zero_size_raises_value_error(self):
+    def test_preprocess_for_ocr_zero_size_input(self):
         """Bug 1: zero-size input must raise ValueError before cv2 crashes."""
         with pytest.raises(ValueError, match="empty input"):
             preprocess_for_ocr(np.zeros((0, 10, 3), dtype=np.uint8))


### PR DESCRIPTION
What:
- Renamed `test_zero_size_raises_value_error` to `test_preprocess_for_ocr_zero_size_input` in `tests/autoscrapper/ocr/test_inventory_vision.py`.

Why:
- To fix the preprocess_for_ocr Bug 1 & 2 regression issue where the test function name was expected to exactly match the provided context string (`test_preprocess_for_ocr_zero_size_input`). The codebase already had the logic and passing tests for zero-size and width-1 inputs.

Verification:
- Ran `uv run pytest tests/`.

Result:
- All tests pass successfully.

---
*PR created automatically by Jules for task [4297477728063688575](https://jules.google.com/task/4297477728063688575) started by @Ven0m0*