### PR TITLE
🧹 Refactor: Extract duplicated duration formatting into shared utility

### DIFF
--- a/src/autoscrapper/scanner/live_ui.py
+++ b/src/autoscrapper/scanner/live_ui.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import cast
 
 
+from ..utils.formatting import format_duration
 from .outcomes import _outcome_style
 from .rich_support import (
     Align,
@@ -38,17 +39,6 @@ AUTOSCRAPPER_ASCII = r"""
 /_/ |_|\_,_/\__/\___/___/\__/_/  \_,_/ .__/ .__/\__/_/
                                    /_/  /_/
 """.strip("\n")
-
-
-def _format_duration(seconds: float | None) -> str:
-    if seconds is None:
-        return "--:--"
-    seconds = max(seconds, 0)
-    minutes, secs = divmod(int(seconds), 60)
-    hours, minutes = divmod(minutes, 60)
-    if hours:
-        return f"{hours:d}:{minutes:02d}:{secs:02d}"
-    return f"{minutes:02d}:{secs:02d}"
 
 
 class _ItemsPerSecondColumn(ProgressColumn):
@@ -225,7 +215,7 @@ class _ScanLiveUI:
             left.add_row("Pages", self.pages_label)
         if self._scan_started_at is not None:
             elapsed = time.perf_counter() - self._scan_started_at
-            left.add_row("Elapsed", _format_duration(elapsed))
+            left.add_row("Elapsed", format_duration(elapsed))
             left.add_row("Completion ETA", self._completion_eta_label())
 
         right = Table.grid(padding=(0, 1))

--- a/src/autoscrapper/tui/scan.py
+++ b/src/autoscrapper/tui/scan.py
@@ -29,6 +29,7 @@ from ..interaction.ui_windows import (
 from ..ocr.tesseract import initialize_ocr
 from ..scanner.outcomes import _describe_action, _outcome_style
 from ..scanner.progress import ScanProgress
+from ..utils.formatting import format_duration
 from ..scanner.types import ScanStats
 from ..warmup import start_background_warmup, warmup_status
 from .common import AppScreen, MessageScreen
@@ -57,17 +58,6 @@ class ScanState:
     counts: Counter[str] = field(default_factory=Counter)
     events: deque[Text] = field(default_factory=lambda: deque(maxlen=EVENT_LIMIT))
     start_time: float | None = None
-
-
-def _format_duration(seconds: float | None) -> str:
-    if seconds is None:
-        return "--:--"
-    seconds = max(seconds, 0)
-    minutes, secs = divmod(int(seconds), 60)
-    hours, minutes = divmod(minutes, 60)
-    if hours:
-        return f"{hours:d}:{minutes:02d}:{secs:02d}"
-    return f"{minutes:02d}:{secs:02d}"
 
 
 def _item_label(result: Any) -> str:
@@ -474,7 +464,7 @@ class ScanScreen(Screen):
         if self._state.start_time is not None:
             elapsed = time.perf_counter() - self._state.start_time
             text.append("Elapsed: ", style="cyan")
-            text.append(_format_duration(elapsed))
+            text.append(format_duration(elapsed))
             text.append("\n")
             speed = self._speed(elapsed)
             if speed is not None:

--- a/src/autoscrapper/utils/__init__.py
+++ b/src/autoscrapper/utils/__init__.py
@@ -1,1 +1,2 @@
 # Autoscrapper utilities package
+from .formatting import format_duration

--- a/src/autoscrapper/utils/formatting.py
+++ b/src/autoscrapper/utils/formatting.py
@@ -1,0 +1,14 @@
+"""Shared formatting utilities."""
+
+from __future__ import annotations
+
+
+def format_duration(seconds: float | None) -> str:
+    if seconds is None:
+        return "--:--"
+    seconds = max(seconds, 0)
+    minutes, secs = divmod(int(seconds), 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours:d}:{minutes:02d}:{secs:02d}"
+    return f"{minutes:02d}:{secs:02d}"

--- a/tests/autoscrapper/utils/test_formatting.py
+++ b/tests/autoscrapper/utils/test_formatting.py
@@ -1,0 +1,10 @@
+from autoscrapper.utils.formatting import format_duration
+
+def test_format_duration():
+    assert format_duration(None) == "--:--"
+    assert format_duration(-10) == "00:00"
+    assert format_duration(0) == "00:00"
+    assert format_duration(45) == "00:45"
+    assert format_duration(65) == "01:05"
+    assert format_duration(3665) == "1:01:05"
+    assert format_duration(125.5) == "02:05"


### PR DESCRIPTION
🎯 **What:** Extracted `_format_duration` from `src/autoscrapper/scanner/live_ui.py` and `src/autoscrapper/tui/scan.py` into a single `format_duration` utility in `src/autoscrapper/utils/formatting.py`.
💡 **Why:** Reduces code duplication and improves maintainability by centralizing pure utility functions into a shared module.
✅ **Verification:** Added comprehensive tests for `format_duration` and successfully ran the full test suite (`uv run pytest tests/`).
✨ **Result:** Improved code health and test coverage without modifying existing behavior.

---
*PR created automatically by Jules for task [6173138454229861528](https://jules.google.com/task/6173138454229861528) started by @Ven0m0*