### PR TITLE
test: add missing regression test for stash icon noise in OCR inventory count

### DIFF
--- a/tests/autoscrapper/ocr/test_inventory_vision.py
+++ b/tests/autoscrapper/ocr/test_inventory_vision.py
@@ -342,9 +342,9 @@ class TestOcrTitleStripCache:
         # 2. no-upscale fallback
         # 3. inverted polarity fallback (T024)
         # 3 × 2 = 6.
-        assert (
-            mock_ocr.call_count == 6
-        ), "image_to_string called 6 times: 3 per invocation (upscale + no-upscale + inverted)"
+        assert mock_ocr.call_count == 6, (
+            "image_to_string called 6 times: 3 per invocation (upscale + no-upscale + inverted)"
+        )
 
     def test_non_empty_result_is_cached(self):
         """When item_name is non-empty, the second call must use the cache."""
@@ -502,6 +502,11 @@ class TestOcrInventoryCount:
         assert count is None
         capsys.readouterr()  # consume log
 
+    def test_ocr_inventory_count_stash_icon_noise(self):
+        """Stash icon can cause a false prefix digit. Ensure fix handles it."""
+        count, _ = self._call("8 197/232")
+        assert count == 197
+
     def test_no_slash_pattern_falls_through_to_digit_fallback(self):
         """No N/M pattern — falls through to digit extraction path."""
         count, _ = self._call("251")
@@ -561,9 +566,9 @@ class TestFindContextMenuCrop:
         assert result is not None, "crop should succeed on a bright image"
         x, _, w, _ = result
         right_edge = x + w
-        assert (
-            right_edge >= cx + 200
-        ), f"right edge {right_edge} is only {right_edge - cx} px past centre {cx}; title text will be clipped"
+        assert right_edge >= cx + 200, (
+            f"right edge {right_edge} is only {right_edge - cx} px past centre {cx}; title text will be clipped"
+        )
 
     def test_right_edge_extends_at_least_200px_near_left_screen(self):
         """Same geometry holds when cell is near the left screen edge."""
@@ -573,9 +578,9 @@ class TestFindContextMenuCrop:
         x, _, w, _ = result
         right_edge = x + w
         # Crop is clamped to screen, but must still extend past centre
-        assert (
-            right_edge >= cx + 200 or right_edge == self._W
-        ), "right edge must reach 200 px past centre or be clamped to screen width"
+        assert right_edge >= cx + 200 or right_edge == self._W, (
+            "right edge must reach 200 px past centre or be clamped to screen width"
+        )
 
     def test_crop_stays_within_image_bounds(self):
         """Crop rectangle must not exceed image dimensions."""


### PR DESCRIPTION
Added the `test_ocr_inventory_count_stash_icon_noise` test case to `TestOcrInventoryCount` in `tests/autoscrapper/ocr/test_inventory_vision.py`.

The underlying phantom-digit extraction fix for handling stash icon prefixes in inventory counts is working correctly but lacked its corresponding regression test, which was identified as a missing item. Codebase coverage is improved by definitively checking the single prefix digit artifact isolation in the OCR response. All tests execute and pass properly without any regression.

---
*PR created automatically by Jules for task [2210674245483535684](https://jules.google.com/task/2210674245483535684) started by @Ven0m0*